### PR TITLE
fix(ui): preserve taskbar monitor selection across display changes

### DIFF
--- a/src/native_interop.rs
+++ b/src/native_interop.rs
@@ -1,5 +1,8 @@
 use windows::core::PCWSTR;
 use windows::Win32::Foundation::{BOOL, HWND, LPARAM, RECT};
+use windows::Win32::Graphics::Gdi::{
+    GetMonitorInfoW, MonitorFromWindow, MONITORINFOEXW, MONITOR_DEFAULTTONEAREST,
+};
 use windows::Win32::UI::Accessibility::{SetWinEventHook, UnhookWinEvent, HWINEVENTHOOK};
 use windows::Win32::UI::Shell::{SHAppBarMessage, ABM_GETTASKBARPOS, APPBARDATA};
 use windows::Win32::UI::WindowsAndMessaging::*;
@@ -24,10 +27,33 @@ pub const WM_APP: u32 = 0x8000;
 pub const WM_APP_USAGE_UPDATED: u32 = WM_APP + 1;
 pub const WM_APP_TRAY: u32 = WM_APP + 3;
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Debug)]
 pub struct TaskbarWindow {
     pub hwnd: HWND,
     pub rect: RECT,
+    /// Stable monitor identity (e.g. "\\\\.\\DISPLAY1"). Used to keep the widget
+    /// anchored to the same physical monitor across topology changes, where the
+    /// geometric ordering (and therefore the index) of taskbars can shift.
+    pub device: String,
+}
+
+/// Stable identifier of the monitor a window currently lives on.
+pub fn monitor_device_name(hwnd: HWND) -> String {
+    unsafe {
+        let monitor = MonitorFromWindow(hwnd, MONITOR_DEFAULTTONEAREST);
+        let mut info = MONITORINFOEXW::default();
+        info.monitorInfo.cbSize = std::mem::size_of::<MONITORINFOEXW>() as u32;
+        if GetMonitorInfoW(monitor, &mut info as *mut _ as *mut _).as_bool() {
+            let len = info
+                .szDevice
+                .iter()
+                .position(|&c| c == 0)
+                .unwrap_or(info.szDevice.len());
+            String::from_utf16_lossy(&info.szDevice[..len])
+        } else {
+            String::new()
+        }
+    }
 }
 
 pub fn find_taskbars() -> Vec<TaskbarWindow> {
@@ -39,7 +65,8 @@ pub fn find_taskbars() -> Vec<TaskbarWindow> {
             let class_name = String::from_utf16_lossy(&class_name[..len as usize]);
             if class_name == "Shell_TrayWnd" || class_name == "Shell_SecondaryTrayWnd" {
                 if let Some(rect) = get_taskbar_rect(hwnd).or_else(|| get_window_rect_safe(hwnd)) {
-                    taskbars.push(TaskbarWindow { hwnd, rect });
+                    let device = monitor_device_name(hwnd);
+                    taskbars.push(TaskbarWindow { hwnd, rect, device });
                 }
             }
         }

--- a/src/native_interop.rs
+++ b/src/native_interop.rs
@@ -31,10 +31,15 @@ pub const WM_APP_TRAY: u32 = WM_APP + 3;
 pub struct TaskbarWindow {
     pub hwnd: HWND,
     pub rect: RECT,
-    /// Stable monitor identity (e.g. "\\\\.\\DISPLAY1"). Used to keep the widget
-    /// anchored to the same physical monitor across topology changes, where the
-    /// geometric ordering (and therefore the index) of taskbars can shift.
+    /// Monitor identity (e.g. "\\\\.\\DISPLAY1"). Best-effort anchor across
+    /// topology changes. NOTE: \\.\DISPLAYn numbers can be reassigned when
+    /// monitors are connected/disconnected, so this is not a fully stable id —
+    /// `primary` is the reliable fallback.
     pub device: String,
+    /// True for the primary taskbar (`Shell_TrayWnd`). Secondary-monitor
+    /// taskbars are `Shell_SecondaryTrayWnd`. The primary taskbar always lives
+    /// on the primary monitor, so it is the safe default/fallback target.
+    pub primary: bool,
 }
 
 /// Stable identifier of the monitor a window currently lives on.
@@ -66,7 +71,13 @@ pub fn find_taskbars() -> Vec<TaskbarWindow> {
             if class_name == "Shell_TrayWnd" || class_name == "Shell_SecondaryTrayWnd" {
                 if let Some(rect) = get_taskbar_rect(hwnd).or_else(|| get_window_rect_safe(hwnd)) {
                     let device = monitor_device_name(hwnd);
-                    taskbars.push(TaskbarWindow { hwnd, rect, device });
+                    let primary = class_name == "Shell_TrayWnd";
+                    taskbars.push(TaskbarWindow {
+                        hwnd,
+                        rect,
+                        device,
+                        primary,
+                    });
                 }
             }
         }

--- a/src/native_interop.rs
+++ b/src/native_interop.rs
@@ -21,6 +21,7 @@ pub const TIMER_POLL: usize = 1;
 pub const TIMER_COUNTDOWN: usize = 2;
 pub const TIMER_RESET_POLL: usize = 3;
 pub const TIMER_UPDATE_CHECK: usize = 4;
+pub const TIMER_ATTACH_RETRY: usize = 5;
 
 // Custom messages
 pub const WM_APP: u32 = 0x8000;
@@ -31,18 +32,10 @@ pub const WM_APP_TRAY: u32 = WM_APP + 3;
 pub struct TaskbarWindow {
     pub hwnd: HWND,
     pub rect: RECT,
-    /// Monitor identity (e.g. "\\\\.\\DISPLAY1"). Best-effort anchor across
-    /// topology changes. NOTE: \\.\DISPLAYn numbers can be reassigned when
-    /// monitors are connected/disconnected, so this is not a fully stable id —
-    /// `primary` is the reliable fallback.
     pub device: String,
-    /// True for the primary taskbar (`Shell_TrayWnd`). Secondary-monitor
-    /// taskbars are `Shell_SecondaryTrayWnd`. The primary taskbar always lives
-    /// on the primary monitor, so it is the safe default/fallback target.
     pub primary: bool,
 }
 
-/// Stable identifier of the monitor a window currently lives on.
 pub fn monitor_device_name(hwnd: HWND) -> String {
     unsafe {
         let monitor = MonitorFromWindow(hwnd, MONITOR_DEFAULTTONEAREST);

--- a/src/native_interop.rs
+++ b/src/native_interop.rs
@@ -13,6 +13,7 @@ pub const WS_CHILD_STYLE: u32 = 0x40000000;
 pub const WS_CLIPSIBLINGS_STYLE: u32 = 0x04000000;
 
 // Win event constants
+pub const EVENT_SYSTEM_FOREGROUND: u32 = 0x0003;
 pub const EVENT_OBJECT_LOCATIONCHANGE: u32 = 0x800B;
 pub const WINEVENT_OUTOFCONTEXT: u32 = 0x0000;
 
@@ -22,6 +23,7 @@ pub const TIMER_COUNTDOWN: usize = 2;
 pub const TIMER_RESET_POLL: usize = 3;
 pub const TIMER_UPDATE_CHECK: usize = 4;
 pub const TIMER_ATTACH_RETRY: usize = 5;
+pub const TIMER_ZGUARD: usize = 6;
 
 // Custom messages
 pub const WM_APP: u32 = 0x8000;
@@ -192,6 +194,47 @@ pub fn set_tray_event_hook(
         } else {
             Some(hook)
         }
+    }
+}
+
+/// Set up a system-wide WinEvent hook for foreground changes (e.g. the Start
+/// menu or a taskbar flyout opening/closing). Delivered on the installing
+/// thread's message loop (OUTOFCONTEXT), so the callback runs on our UI thread.
+pub fn set_foreground_event_hook(
+    callback: unsafe extern "system" fn(HWINEVENTHOOK, u32, HWND, i32, i32, u32, u32),
+) -> Option<HWINEVENTHOOK> {
+    unsafe {
+        let hook = SetWinEventHook(
+            EVENT_SYSTEM_FOREGROUND,
+            EVENT_SYSTEM_FOREGROUND,
+            None,
+            Some(callback),
+            0,
+            0,
+            WINEVENT_OUTOFCONTEXT,
+        );
+        if hook.is_invalid() {
+            None
+        } else {
+            Some(hook)
+        }
+    }
+}
+
+/// Re-assert the window to the top of its sibling z-order without moving,
+/// resizing or activating it. Used to recover after the shell buries our
+/// taskbar-embedded child behind the taskbar backdrop.
+pub fn raise_to_top(hwnd: HWND) {
+    unsafe {
+        let _ = SetWindowPos(
+            hwnd,
+            HWND_TOP,
+            0,
+            0,
+            0,
+            0,
+            SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE,
+        );
     }
 }
 

--- a/src/window.rs
+++ b/src/window.rs
@@ -510,14 +510,27 @@ fn attach_to_taskbar(
         return false;
     }
 
-    // Prefer the taskbar on the same physical monitor we were last anchored to.
-    // The geometric index is unstable across monitor connect/disconnect/reorder,
-    // so matching by device name keeps the widget on the user's chosen monitor.
-    let index = requested_device
+    // Selection priority:
+    //   1. The taskbar on the monitor we were last anchored to (device match).
+    //   2. The PRIMARY taskbar (Shell_TrayWnd). Critically NOT geometric index
+    //      0: find_taskbars sorts by rect.top/left, so a secondary monitor
+    //      placed above/left of the primary sorts first — falling back to
+    //      index 0 is exactly how the widget "randomly" jumped to the second
+    //      monitor. \\.\DISPLAYn device numbers can also be reassigned across
+    //      connect/disconnect, breaking the device match, so the primary
+    //      taskbar is the reliable fallback.
+    //   3. As a last resort, the saved index (legacy / no primary found).
+    let device_match = requested_device
         .filter(|d| !d.is_empty())
-        .and_then(|device| taskbars.iter().position(|t| t.device == device))
+        .and_then(|device| taskbars.iter().position(|t| t.device == device));
+    let index = device_match
+        .or_else(|| taskbars.iter().position(|t| t.primary))
         .unwrap_or_else(|| requested_index.min(taskbars.len().saturating_sub(1)));
     let taskbar = taskbars[index].clone();
+    diagnose::log(format!(
+        "attach: requested_device={requested_device:?} device_match={device_match:?} -> index={index} primary={}",
+        taskbar.primary
+    ));
     diagnose::log(format!(
         "taskbar selected index={index} device={} count={} hwnd={:?} rect=({}, {}, {}, {})",
         taskbar.device,
@@ -556,14 +569,27 @@ fn attach_to_taskbar(
         diagnose::log("tray event hook could not be installed");
     }
 
-    let mut state = lock_state();
-    if let Some(s) = state.as_mut() {
-        s.taskbar_hwnd = Some(taskbar.hwnd);
-        s.tray_notify_hwnd = tray_notify;
-        s.win_event_hook = hook;
-        s.taskbar_index = index;
-        s.taskbar_device = Some(taskbar.device.clone());
-        s.embedded = true;
+    let device_changed = {
+        let mut state = lock_state();
+        if let Some(s) = state.as_mut() {
+            let changed = s.taskbar_device.as_deref() != Some(taskbar.device.as_str())
+                || s.taskbar_index != index;
+            s.taskbar_hwnd = Some(taskbar.hwnd);
+            s.tray_notify_hwnd = tray_notify;
+            s.win_event_hook = hook;
+            s.taskbar_index = index;
+            s.taskbar_device = Some(taskbar.device.clone());
+            s.embedded = true;
+            changed
+        } else {
+            false
+        }
+    };
+    // Persist the resolved monitor identity right away so a watchdog relaunch
+    // (e.g. on monitor connect/disconnect) re-anchors to the same taskbar
+    // instead of falling back to the unstable geometric index.
+    if device_changed {
+        save_state_settings();
     }
     true
 }

--- a/src/window.rs
+++ b/src/window.rs
@@ -84,6 +84,7 @@ struct AppState {
     last_update_check_unix: Option<u64>,
 
     taskbar_index: usize,
+    taskbar_device: Option<String>,
     tray_offset: i32,
     dragging: bool,
     drag_start_mouse_x: i32,
@@ -302,6 +303,8 @@ struct SettingsFile {
     tray_offset: i32,
     #[serde(default)]
     taskbar_index: usize,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    taskbar_device: Option<String>,
     #[serde(default = "default_poll_interval")]
     poll_interval_ms: u32,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -323,6 +326,7 @@ impl Default for SettingsFile {
         Self {
             tray_offset: 0,
             taskbar_index: 0,
+            taskbar_device: None,
             poll_interval_ms: default_poll_interval(),
             language: None,
             last_update_check_unix: None,
@@ -382,6 +386,7 @@ fn save_state_settings() {
         save_settings(&SettingsFile {
             tray_offset: s.tray_offset,
             taskbar_index: s.taskbar_index,
+            taskbar_device: s.taskbar_device.clone(),
             poll_interval_ms: s.poll_interval_ms,
             language: s
                 .language_override
@@ -494,17 +499,28 @@ fn toggle_widget_visibility(hwnd: HWND) {
     }
 }
 
-fn attach_to_taskbar(hwnd: HWND, requested_index: usize) -> bool {
+fn attach_to_taskbar(
+    hwnd: HWND,
+    requested_index: usize,
+    requested_device: Option<&str>,
+) -> bool {
     let taskbars = native_interop::find_taskbars();
     if taskbars.is_empty() {
         diagnose::log("taskbar not found; using fallback popup window");
         return false;
     }
 
-    let index = requested_index.min(taskbars.len().saturating_sub(1));
-    let taskbar = taskbars[index];
+    // Prefer the taskbar on the same physical monitor we were last anchored to.
+    // The geometric index is unstable across monitor connect/disconnect/reorder,
+    // so matching by device name keeps the widget on the user's chosen monitor.
+    let index = requested_device
+        .filter(|d| !d.is_empty())
+        .and_then(|device| taskbars.iter().position(|t| t.device == device))
+        .unwrap_or_else(|| requested_index.min(taskbars.len().saturating_sub(1)));
+    let taskbar = taskbars[index].clone();
     diagnose::log(format!(
-        "taskbar selected index={index} count={} hwnd={:?} rect=({}, {}, {}, {})",
+        "taskbar selected index={index} device={} count={} hwnd={:?} rect=({}, {}, {}, {})",
+        taskbar.device,
         taskbars.len(),
         taskbar.hwnd,
         taskbar.rect.left,
@@ -546,6 +562,7 @@ fn attach_to_taskbar(hwnd: HWND, requested_index: usize) -> bool {
         s.tray_notify_hwnd = tray_notify;
         s.win_event_hook = hook;
         s.taskbar_index = index;
+        s.taskbar_device = Some(taskbar.device.clone());
         s.embedded = true;
     }
     true
@@ -1321,6 +1338,7 @@ pub fn run() {
                 update_status: UpdateStatus::Idle,
                 last_update_check_unix: settings.last_update_check_unix,
                 taskbar_index: settings.taskbar_index,
+                taskbar_device: settings.taskbar_device.clone(),
                 tray_offset: settings.tray_offset,
                 dragging: false,
                 drag_start_mouse_x: 0,
@@ -1331,7 +1349,7 @@ pub fn run() {
         }
 
         // Try to embed in taskbar
-        if attach_to_taskbar(hwnd, settings.taskbar_index) {
+        if attach_to_taskbar(hwnd, settings.taskbar_index, settings.taskbar_device.as_deref()) {
             embedded = true;
         }
 
@@ -2487,7 +2505,7 @@ unsafe extern "system" fn wnd_proc(
                                 s.tray_offset = new_offset;
                             }
                         }
-                        if attach_to_taskbar(hwnd, target_index) {
+                        if attach_to_taskbar(hwnd, target_index, Some(&target_taskbar.device)) {
                             position_at_taskbar();
                             render_layered();
                         }

--- a/src/window.rs
+++ b/src/window.rs
@@ -21,7 +21,7 @@ use crate::localization::{self, LanguageId, Strings};
 use crate::models::AppUsageData;
 use crate::native_interop::{
     self, Color, TIMER_ATTACH_RETRY, TIMER_COUNTDOWN, TIMER_POLL, TIMER_RESET_POLL,
-    TIMER_UPDATE_CHECK, WM_APP_TRAY, WM_APP_USAGE_UPDATED,
+    TIMER_UPDATE_CHECK, TIMER_ZGUARD, WM_APP_TRAY, WM_APP_USAGE_UPDATED,
 };
 use crate::poller;
 use crate::theme;
@@ -49,6 +49,7 @@ struct AppState {
     taskbar_hwnd: Option<HWND>,
     tray_notify_hwnd: Option<HWND>,
     win_event_hook: Option<HWINEVENTHOOK>,
+    foreground_hook: Option<HWINEVENTHOOK>,
     is_dark: bool,
     embedded: bool,
     language_override: Option<LanguageId>,
@@ -600,6 +601,25 @@ fn attach_to_taskbar(
         diagnose::log("tray event hook installed");
     } else {
         diagnose::log("tray event hook could not be installed");
+    }
+
+    // A system-wide foreground hook lets us recover when the shell buries our
+    // embedded child behind the taskbar backdrop after a Start menu / taskbar
+    // flyout opens or closes. Installed once; reused across re-attaches.
+    let need_foreground_hook = {
+        let state = lock_state();
+        state.as_ref().map(|s| s.foreground_hook.is_none()).unwrap_or(false)
+    };
+    if need_foreground_hook {
+        if let Some(fg_hook) = native_interop::set_foreground_event_hook(on_foreground_changed) {
+            let mut state = lock_state();
+            if let Some(s) = state.as_mut() {
+                s.foreground_hook = Some(fg_hook);
+            }
+            diagnose::log("foreground event hook installed");
+        } else {
+            diagnose::log("foreground event hook could not be installed");
+        }
     }
 
     let device_changed = {
@@ -1372,6 +1392,7 @@ pub fn run() {
                 taskbar_hwnd: None,
                 tray_notify_hwnd: None,
                 win_event_hook: None,
+                foreground_hook: None,
                 is_dark,
                 embedded: false,
                 language_override,
@@ -1460,6 +1481,13 @@ pub fn run() {
                 .unwrap_or(POLL_15_MIN)
         };
         SetTimer(hwnd, TIMER_POLL, initial_poll_ms, None);
+
+        // Z-order guard: while embedded, the shell intermittently buries our
+        // child behind the taskbar backdrop (e.g. after opening the Start menu
+        // or clicking the taskbar) without sending us any window message. A
+        // light periodic re-raise keeps the widget on top; raise_to_top does not
+        // repaint, so this is cheap.
+        SetTimer(hwnd, TIMER_ZGUARD, 200, None);
 
         // Watch for explorer.exe restarts so we can re-embed and re-add the tray
         // icon (the shell discards tray registrations when it restarts). This
@@ -2221,6 +2249,7 @@ fn position_at_taskbar() {
         // Child window: coordinates relative to parent (taskbar)
         let x = tray_left - taskbar_rect.left - widget_width - tray_offset;
         native_interop::move_window(hwnd, x, y - taskbar_rect.top, widget_width, widget_height);
+        native_interop::raise_to_top(hwnd);
         diagnose::log(format!(
             "positioned embedded widget at x={x} y={} w={widget_width} h={widget_height}",
             y - taskbar_rect.top
@@ -2286,6 +2315,109 @@ unsafe extern "system" fn on_tray_location_changed(
     }
 }
 
+/// Periodic z-order guard. While embedded, keep the widget on top of its
+/// taskbar siblings so the shell can't leave it buried behind the taskbar
+/// backdrop. `raise_to_top` does not repaint, so the steady-state cost is a
+/// single SetWindowPos per tick. Diagnostic logging fires only when the
+/// window's visibility or rectangle actually changes.
+fn z_guard_tick(_hwnd: HWND) {
+    static LAST: Mutex<Option<(bool, i32, i32, i32, i32)>> = Mutex::new(None);
+
+    let (hwnd, embedded) = {
+        let state = lock_state();
+        match state.as_ref() {
+            Some(s) if s.embedded => (s.hwnd.to_hwnd(), true),
+            _ => return,
+        }
+    };
+    if !embedded {
+        return;
+    }
+
+    native_interop::raise_to_top(hwnd);
+
+    let visible = unsafe { IsWindowVisible(hwnd).as_bool() };
+    if !visible {
+        let _ = unsafe { ShowWindow(hwnd, SW_SHOWNOACTIVATE) };
+    }
+
+    // DIAGNOSTIC: re-push our layered content every tick. If this stops the
+    // vanish, the cause is the shell compositing its taskbar backdrop over our
+    // child (DirectComposition), not HWND z-order.
+    render_layered();
+
+    let rect = native_interop::get_window_rect_safe(hwnd)
+        .map(|r| (r.left, r.top, r.right, r.bottom))
+        .unwrap_or((0, 0, 0, 0));
+    let snapshot = (visible, rect.0, rect.1, rect.2, rect.3);
+    let changed = {
+        let mut last = LAST.lock().unwrap_or_else(|e| e.into_inner());
+        if last.as_ref() != Some(&snapshot) {
+            *last = Some(snapshot);
+            true
+        } else {
+            false
+        }
+    };
+    let _ = changed;
+    diagnose::log(format!(
+        "zguard tick: visible={visible} rect=({}, {}, {}, {})",
+        rect.0, rect.1, rect.2, rect.3
+    ));
+}
+
+/// WinEvent callback for system foreground changes. When the Start menu or a
+/// taskbar flyout opens/closes the shell reorders its taskbar children and our
+/// embedded widget gets buried behind the taskbar backdrop (it "disappears").
+/// Re-raising it to the top of the sibling z-order and re-rendering restores it.
+unsafe extern "system" fn on_foreground_changed(
+    _hook: HWINEVENTHOOK,
+    _event: u32,
+    _hwnd: HWND,
+    _id_object: i32,
+    _id_child: i32,
+    _thread: u32,
+    _time: u32,
+) {
+    static LAST_RAISE: Mutex<Option<std::time::Instant>> = Mutex::new(None);
+
+    let (hwnd, embedded) = {
+        let state = lock_state();
+        match state.as_ref() {
+            Some(s) if s.embedded => (s.hwnd.to_hwnd(), true),
+            _ => return,
+        }
+    };
+    if !embedded {
+        return;
+    }
+
+    // Foreground changes fire frequently; debounce so we don't thrash.
+    let should_raise = {
+        let mut last = LAST_RAISE.lock().unwrap_or_else(|e| e.into_inner());
+        let now = std::time::Instant::now();
+        if last
+            .map(|t| now.duration_since(t).as_millis() > 150)
+            .unwrap_or(true)
+        {
+            *last = Some(now);
+            true
+        } else {
+            false
+        }
+    };
+    if should_raise {
+        let visible_before = unsafe { IsWindowVisible(hwnd).as_bool() };
+        native_interop::raise_to_top(hwnd);
+        let _ = unsafe { ShowWindow(hwnd, SW_SHOWNOACTIVATE) };
+        position_at_taskbar();
+        render_layered();
+        diagnose::log(format!(
+            "foreground change: raised+repositioned widget (visible_before={visible_before})"
+        ));
+    }
+}
+
 /// Main window procedure
 unsafe extern "system" fn wnd_proc(
     hwnd: HWND,
@@ -2331,6 +2463,9 @@ unsafe extern "system" fn wnd_proc(
         WM_TIMER => {
             let timer_id = wparam.0;
             match timer_id {
+                TIMER_ZGUARD => {
+                    z_guard_tick(hwnd);
+                }
                 TIMER_ATTACH_RETRY => {
                     let (idx, dev) = {
                         let state = lock_state();
@@ -2798,11 +2933,17 @@ unsafe extern "system" fn wnd_proc(
             LRESULT(0)
         }
         WM_DESTROY => {
-            let hook = {
+            let (hook, fg_hook) = {
                 let state = lock_state();
-                state.as_ref().and_then(|s| s.win_event_hook)
+                state
+                    .as_ref()
+                    .map(|s| (s.win_event_hook, s.foreground_hook))
+                    .unwrap_or((None, None))
             };
             if let Some(h) = hook {
+                native_interop::unhook_win_event(h);
+            }
+            if let Some(h) = fg_hook {
                 native_interop::unhook_win_event(h);
             }
             tray_icon::remove_all(hwnd);

--- a/src/window.rs
+++ b/src/window.rs
@@ -173,6 +173,12 @@ fn refresh_dpi() {
 const RELAUNCH_THROTTLE_SECS: u64 = 10;
 const RELAUNCH_BACKOFF_SECS: u64 = 30;
 const ATTACH_RETRY_MS: u32 = 1000;
+/// After this many failed 1s retries (~5s) of finding the pinned/primary
+/// taskbar, give up insisting on it and attach to any available taskbar so the
+/// widget is never left permanently invisible.
+const ATTACH_RETRY_FALLBACK_AFTER: u32 = 5;
+/// Count of consecutive failed attach retries; gates the fallback above.
+static ATTACH_RETRY_ATTEMPTS: AtomicU32 = AtomicU32::new(0);
 /// Environment flag set on a relaunched child so it waits for the previous
 /// instance's single-instance mutex instead of exiting immediately.
 const ENV_RELAUNCH: &str = "CCUM_RELAUNCH";
@@ -504,6 +510,7 @@ fn attach_to_taskbar(
     hwnd: HWND,
     requested_index: usize,
     requested_device: Option<&str>,
+    allow_fallback: bool,
 ) -> bool {
     let taskbars = native_interop::find_taskbars();
     if taskbars.is_empty() {
@@ -518,15 +525,22 @@ fn attach_to_taskbar(
     //
     // If the wanted taskbar is NOT currently enumerable — e.g. explorer is
     // mid-rebuild during a display change and find_taskbars() momentarily
-    // returns only the secondary taskbar — we DO NOT grab whatever happens to
-    // be present. That transient grab is exactly how the widget "randomly"
-    // jumped to the second monitor. Instead we bail and let the retry timer
-    // re-attach once the correct taskbar reappears.
+    // returns only the secondary taskbar — we normally bail and let the retry
+    // timer re-attach once the correct taskbar reappears. That transient grab
+    // is exactly how the widget "randomly" jumped to the second monitor.
+    //
+    // BUT if the wanted taskbar never comes back (e.g. the primary
+    // Shell_TrayWnd's SHAppBarMessage keeps failing, leaving only the secondary
+    // enumerable), bailing forever leaves the widget permanently invisible.
+    // `allow_fallback` is set by the retry timer after a few failed attempts so
+    // we attach to whatever taskbar exists rather than disappear for good.
     let _ = requested_index;
     let device_match = requested_device
         .filter(|d| !d.is_empty())
         .and_then(|device| taskbars.iter().position(|t| t.device == device));
-    let want = device_match.or_else(|| taskbars.iter().position(|t| t.primary));
+    let want = device_match
+        .or_else(|| taskbars.iter().position(|t| t.primary))
+        .or_else(|| allow_fallback.then_some(0));
     let Some(index) = want else {
         diagnose::log(format!(
             "attach: wanted taskbar not present (requested_device={requested_device:?} count={}); will retry",
@@ -534,6 +548,12 @@ fn attach_to_taskbar(
         ));
         return false;
     };
+    if device_match.is_none() && !taskbars[index].primary {
+        diagnose::log(format!(
+            "attach: falling back to non-pinned taskbar index={index} device={} after exhausting retries",
+            taskbars[index].device
+        ));
+    }
     let taskbar = taskbars[index].clone();
     diagnose::log(format!(
         "attach: requested_device={requested_device:?} device_match={device_match:?} -> index={index} primary={}",
@@ -1383,7 +1403,12 @@ pub fn run() {
         }
 
         // Try to embed in taskbar
-        if attach_to_taskbar(hwnd, settings.taskbar_index, settings.taskbar_device.as_deref()) {
+        if attach_to_taskbar(
+            hwnd,
+            settings.taskbar_index,
+            settings.taskbar_device.as_deref(),
+            false,
+        ) {
             embedded = true;
         }
 
@@ -2303,11 +2328,18 @@ unsafe extern "system" fn wnd_proc(
                             .map(|s| (s.taskbar_index, s.taskbar_device.clone()))
                             .unwrap_or((0, None))
                     };
-                    if attach_to_taskbar(hwnd, idx, dev.as_deref()) {
+                    // Prefer the pinned/primary taskbar for the first few
+                    // retries (transient explorer rebuild). If it still hasn't
+                    // come back, allow attaching to any taskbar so the widget is
+                    // never left permanently invisible.
+                    let attempts = ATTACH_RETRY_ATTEMPTS.fetch_add(1, Ordering::Relaxed) + 1;
+                    let allow_fallback = attempts >= ATTACH_RETRY_FALLBACK_AFTER;
+                    if attach_to_taskbar(hwnd, idx, dev.as_deref(), allow_fallback) {
                         let _ = KillTimer(hwnd, TIMER_ATTACH_RETRY);
+                        ATTACH_RETRY_ATTEMPTS.store(0, Ordering::Relaxed);
                         position_at_taskbar();
                         render_layered();
-                        diagnose::log("attach retry succeeded; re-homed to pinned taskbar");
+                        diagnose::log("attach retry succeeded; re-homed to taskbar");
                     }
                 }
                 TIMER_POLL => {
@@ -2555,7 +2587,7 @@ unsafe extern "system" fn wnd_proc(
                                 s.tray_offset = new_offset;
                             }
                         }
-                        if attach_to_taskbar(hwnd, target_index, Some(&target_taskbar.device)) {
+                        if attach_to_taskbar(hwnd, target_index, Some(&target_taskbar.device), true) {
                             position_at_taskbar();
                             render_layered();
                         }

--- a/src/window.rs
+++ b/src/window.rs
@@ -548,7 +548,12 @@ fn attach_to_taskbar(
         ));
         return false;
     };
-    if device_match.is_none() && !taskbars[index].primary {
+    // A fallback attach (neither the pinned device nor the primary taskbar) is a
+    // degraded "don't disappear" state, not a deliberate re-home. Keep it
+    // session-only: show the widget here but do NOT overwrite the user's saved
+    // pin, so the next launch still retries the real pinned/primary taskbar.
+    let is_fallback = device_match.is_none() && !taskbars[index].primary;
+    if is_fallback {
         diagnose::log(format!(
             "attach: falling back to non-pinned taskbar index={index} device={} after exhausting retries",
             taskbars[index].device
@@ -600,15 +605,21 @@ fn attach_to_taskbar(
     let device_changed = {
         let mut state = lock_state();
         if let Some(s) = state.as_mut() {
-            let changed = s.taskbar_device.as_deref() != Some(taskbar.device.as_str())
-                || s.taskbar_index != index;
             s.taskbar_hwnd = Some(taskbar.hwnd);
             s.tray_notify_hwnd = tray_notify;
             s.win_event_hook = hook;
-            s.taskbar_index = index;
-            s.taskbar_device = Some(taskbar.device.clone());
             s.embedded = true;
-            changed
+            // Only re-pin (and persist) when this is the wanted taskbar. A
+            // fallback attach must not overwrite the user's saved monitor pin.
+            if is_fallback {
+                false
+            } else {
+                let changed = s.taskbar_device.as_deref() != Some(taskbar.device.as_str())
+                    || s.taskbar_index != index;
+                s.taskbar_index = index;
+                s.taskbar_device = Some(taskbar.device.clone());
+                changed
+            }
         } else {
             false
         }

--- a/src/window.rs
+++ b/src/window.rs
@@ -20,8 +20,8 @@ use crate::diagnose;
 use crate::localization::{self, LanguageId, Strings};
 use crate::models::AppUsageData;
 use crate::native_interop::{
-    self, Color, TIMER_COUNTDOWN, TIMER_POLL, TIMER_RESET_POLL, TIMER_UPDATE_CHECK, WM_APP_TRAY,
-    WM_APP_USAGE_UPDATED,
+    self, Color, TIMER_ATTACH_RETRY, TIMER_COUNTDOWN, TIMER_POLL, TIMER_RESET_POLL,
+    TIMER_UPDATE_CHECK, WM_APP_TRAY, WM_APP_USAGE_UPDATED,
 };
 use crate::poller;
 use crate::theme;
@@ -172,6 +172,7 @@ fn refresh_dpi() {
 /// crash-looping); when detected we back off instead of spawning in a tight loop.
 const RELAUNCH_THROTTLE_SECS: u64 = 10;
 const RELAUNCH_BACKOFF_SECS: u64 = 30;
+const ATTACH_RETRY_MS: u32 = 1000;
 /// Environment flag set on a relaunched child so it waits for the previous
 /// instance's single-instance mutex instead of exiting immediately.
 const ENV_RELAUNCH: &str = "CCUM_RELAUNCH";
@@ -510,22 +511,29 @@ fn attach_to_taskbar(
         return false;
     }
 
-    // Selection priority:
-    //   1. The taskbar on the monitor we were last anchored to (device match).
-    //   2. The PRIMARY taskbar (Shell_TrayWnd). Critically NOT geometric index
-    //      0: find_taskbars sorts by rect.top/left, so a secondary monitor
-    //      placed above/left of the primary sorts first — falling back to
-    //      index 0 is exactly how the widget "randomly" jumped to the second
-    //      monitor. \\.\DISPLAYn device numbers can also be reassigned across
-    //      connect/disconnect, breaking the device match, so the primary
-    //      taskbar is the reliable fallback.
-    //   3. As a last resort, the saved index (legacy / no primary found).
+    // We attach ONLY to the taskbar we want, and never auto-switch monitors:
+    //   1. The taskbar on the monitor we are pinned to (device match).
+    //   2. If we have no pin yet (first run), the PRIMARY taskbar
+    //      (Shell_TrayWnd) — its monitor is the stable default home.
+    //
+    // If the wanted taskbar is NOT currently enumerable — e.g. explorer is
+    // mid-rebuild during a display change and find_taskbars() momentarily
+    // returns only the secondary taskbar — we DO NOT grab whatever happens to
+    // be present. That transient grab is exactly how the widget "randomly"
+    // jumped to the second monitor. Instead we bail and let the retry timer
+    // re-attach once the correct taskbar reappears.
+    let _ = requested_index;
     let device_match = requested_device
         .filter(|d| !d.is_empty())
         .and_then(|device| taskbars.iter().position(|t| t.device == device));
-    let index = device_match
-        .or_else(|| taskbars.iter().position(|t| t.primary))
-        .unwrap_or_else(|| requested_index.min(taskbars.len().saturating_sub(1)));
+    let want = device_match.or_else(|| taskbars.iter().position(|t| t.primary));
+    let Some(index) = want else {
+        diagnose::log(format!(
+            "attach: wanted taskbar not present (requested_device={requested_device:?} count={}); will retry",
+            taskbars.len()
+        ));
+        return false;
+    };
     let taskbar = taskbars[index].clone();
     diagnose::log(format!(
         "attach: requested_device={requested_device:?} device_match={device_match:?} -> index={index} primary={}",
@@ -1391,6 +1399,7 @@ pub fn run() {
                 0,
                 SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE,
             );
+            SetTimer(hwnd, TIMER_ATTACH_RETRY, ATTACH_RETRY_MS, None);
         }
 
         // Register system tray icon(s)
@@ -2286,6 +2295,21 @@ unsafe extern "system" fn wnd_proc(
         WM_TIMER => {
             let timer_id = wparam.0;
             match timer_id {
+                TIMER_ATTACH_RETRY => {
+                    let (idx, dev) = {
+                        let state = lock_state();
+                        state
+                            .as_ref()
+                            .map(|s| (s.taskbar_index, s.taskbar_device.clone()))
+                            .unwrap_or((0, None))
+                    };
+                    if attach_to_taskbar(hwnd, idx, dev.as_deref()) {
+                        let _ = KillTimer(hwnd, TIMER_ATTACH_RETRY);
+                        position_at_taskbar();
+                        render_layered();
+                        diagnose::log("attach retry succeeded; re-homed to pinned taskbar");
+                    }
+                }
                 TIMER_POLL => {
                     let auth_watch = {
                         let state = lock_state();


### PR DESCRIPTION
Store the selected taskbar's monitor device name in settings and prefer it when reattaching the widget.

This keeps the widget anchored to the same physical monitor when taskbar ordering changes after monitor connect, disconnect, or reconfiguration, while still falling back to the saved index for existing settings and compatibility.