### PR TITLE
feat: ollama cloud usage meter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,16 +9,115 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "atk"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "241b621213072e993be4f6f3a9e4b45f65b7e6faad43001be957184b7bb1824b"
+dependencies = [
+ "atk-sys",
+ "glib",
+ "libc",
+]
+
+[[package]]
+name = "atk-sys"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5e48b684b0ca77d2bbadeef17424c2ea3c897d44d566a1617e7e8f30614d086"
+dependencies = [
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "system-deps",
+]
+
+[[package]]
+name = "autocfg"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
 name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "block2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+dependencies = [
+ "objc2",
+]
+
+[[package]]
+name = "bytes"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
+
+[[package]]
+name = "cairo-rs"
+version = "0.18.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ca26ef0159422fb77631dc9d17b102f253b876fe1586b03b803e63a309b4ee2"
+dependencies = [
+ "bitflags 2.11.0",
+ "cairo-sys-rs",
+ "glib",
+ "libc",
+ "once_cell",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "cairo-sys-rs"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "685c9fa8e590b8b3d678873528d83411db17242a73fccaed827770ea0fedda51"
+dependencies = [
+ "glib-sys",
+ "libc",
+ "system-deps",
+]
 
 [[package]]
 name = "cc"
@@ -28,6 +127,22 @@ checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
 dependencies = [
  "find-msvc-tools",
  "shlex",
+]
+
+[[package]]
+name = "cesu8"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
+
+[[package]]
+name = "cfg-expr"
+version = "0.15.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d067ad48b8650848b989a59a86c6c36a995d02d2bf778d45c3c5d57bc2718f02"
+dependencies = [
+ "smallvec",
+ "target-lexicon",
 ]
 
 [[package]]
@@ -44,9 +159,31 @@ dependencies = [
  "native-tls",
  "serde",
  "serde_json",
+ "tao",
  "ureq",
- "windows",
+ "windows 0.58.0",
  "winres",
+ "wry",
+]
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
+
+[[package]]
+name = "cookie"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
+dependencies = [
+ "time",
+ "version_check",
 ]
 
 [[package]]
@@ -66,6 +203,135 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "core-graphics"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "064badf302c3194842cf2c5d61f56cc88e54a759313879cdf03abdd27d0c3b97"
+dependencies = [
+ "bitflags 2.11.0",
+ "core-foundation",
+ "core-graphics-types",
+ "foreign-types 0.5.0",
+ "libc",
+]
+
+[[package]]
+name = "core-graphics-types"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
+dependencies = [
+ "bitflags 2.11.0",
+ "core-foundation",
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d85363c37faeca707aef026efa9f3b34d077bce547e48f770770625c6013679e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "cssparser"
+version = "0.36.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dae61cf9c0abb83bd659dab65b7e4e38d8236824c85f0f804f173567bda257d2"
+dependencies = [
+ "cssparser-macros",
+ "dtoa-short",
+ "itoa",
+ "phf",
+ "smallvec",
+]
+
+[[package]]
+name = "cssparser-macros"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "dbus"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ab69f03cc8c4340c9c8e315114e1658e6775a9b16a04357973aa21cec22b32e"
+dependencies = [
+ "libc",
+ "libdbus-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+
+[[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
 name = "dirs"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -83,7 +349,19 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags 2.11.0",
+ "block2",
+ "libc",
+ "objc2",
 ]
 
 [[package]]
@@ -94,8 +372,73 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
+
+[[package]]
+name = "dlopen2"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e2c5bd4158e66d1e215c49b837e11d62f3267b30c92f1d171c4d3105e3dc4d4"
+dependencies = [
+ "dlopen2_derive",
+ "libc",
+ "once_cell",
+ "winapi",
+]
+
+[[package]]
+name = "dlopen2_derive"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fbbb781877580993a8707ec48672673ec7b81eeba04cfd2310bd28c08e47c8f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "dom_query"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521e380c0c8afb8d9a1e83a1822ee03556fc3e3e7dbc1fd30be14e37f9cb3f89"
+dependencies = [
+ "bit-set",
+ "cssparser",
+ "foldhash 0.2.0",
+ "html5ever",
+ "precomputed-hash",
+ "selectors",
+ "tendril",
+]
+
+[[package]]
+name = "dpi"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b14ccef22fc6f5a8f4d7d768562a182c04ce9a3b3157b91390b52ddfdf1a76"
+
+[[package]]
+name = "dtoa"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c3cf4824e2d5f025c7b531afcb2325364084a16806f6d47fbc1f5fbd9960590"
+
+[[package]]
+name = "dtoa-short"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd1511a7b6a56299bd043a9c167a6d2bfb37bf84a6dfceaba651168adfb43c87"
+dependencies = [
+ "dtoa",
+]
+
+[[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "equivalent"
@@ -110,7 +453,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -118,6 +461,16 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "field-offset"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38e2275cc4e4fc009b0669731a1e5ab7ebf11f469eaede2bab9309a5b4d6057f"
+dependencies = [
+ "memoffset",
+ "rustc_version",
+]
 
 [[package]]
 name = "find-msvc-tools"
@@ -132,12 +485,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
 name = "foreign-types"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
 dependencies = [
- "foreign-types-shared",
+ "foreign-types-shared 0.1.1",
+]
+
+[[package]]
+name = "foreign-types"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
+dependencies = [
+ "foreign-types-macros",
+ "foreign-types-shared 0.3.1",
+]
+
+[[package]]
+name = "foreign-types-macros"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea5190182e6915eb873ddbc16e23b711b6eb1f9c00a0d0a3a91b5f6228475225"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -147,12 +527,189 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
+name = "foreign-types-shared"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "262590f4fe6afeb0bc83be1daa64e52657fe185690a958af7f3ad0e92085c5ae"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6754879cc9f2c66f88c6e5c35344bb0bdb0708b0352b1201815667c7eabc7458"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d6d3cde68c518367be28956066ddfef33813991b77a55005a69dae04bf3b10b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "futures-task"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
+
+[[package]]
+name = "futures-util"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
+dependencies = [
+ "futures-core",
+ "futures-macro",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "gdk"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9f245958c627ac99d8e529166f9823fb3b838d1d41fd2b297af3075093c2691"
+dependencies = [
+ "cairo-rs",
+ "gdk-pixbuf",
+ "gdk-sys",
+ "gio",
+ "glib",
+ "libc",
+ "pango",
+]
+
+[[package]]
+name = "gdk-pixbuf"
+version = "0.18.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50e1f5f1b0bfb830d6ccc8066d18db35c487b1b2b1e8589b5dfe9f07e8defaec"
+dependencies = [
+ "gdk-pixbuf-sys",
+ "gio",
+ "glib",
+ "libc",
+ "once_cell",
+]
+
+[[package]]
+name = "gdk-pixbuf-sys"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9839ea644ed9c97a34d129ad56d38a25e6756f99f3a88e15cd39c20629caf7"
+dependencies = [
+ "gio-sys",
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "system-deps",
+]
+
+[[package]]
+name = "gdk-sys"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c2d13f38594ac1e66619e188c6d5a1adb98d11b2fcf7894fc416ad76aa2f3f7"
+dependencies = [
+ "cairo-sys-rs",
+ "gdk-pixbuf-sys",
+ "gio-sys",
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "pango-sys",
+ "pkg-config",
+ "system-deps",
+]
+
+[[package]]
+name = "gdkwayland-sys"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "140071d506d223f7572b9f09b5e155afbd77428cd5cc7af8f2694c41d98dfe69"
+dependencies = [
+ "gdk-sys",
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "pkg-config",
+ "system-deps",
+]
+
+[[package]]
+name = "gdkx11"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3caa00e14351bebbc8183b3c36690327eb77c49abc2268dd4bd36b856db3fbfe"
+dependencies = [
+ "gdk",
+ "gdkx11-sys",
+ "gio",
+ "glib",
+ "libc",
+ "x11",
+]
+
+[[package]]
+name = "gdkx11-sys"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e7445fe01ac26f11601db260dd8608fe172514eb63b3b5e261ea6b0f4428d"
+dependencies = [
+ "gdk-sys",
+ "glib-sys",
+ "libc",
+ "system-deps",
+ "x11",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -180,12 +737,154 @@ dependencies = [
 ]
 
 [[package]]
+name = "gio"
+version = "0.18.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4fc8f532f87b79cbc51a79748f16a6828fb784be93145a322fa14d06d354c73"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-util",
+ "gio-sys",
+ "glib",
+ "libc",
+ "once_cell",
+ "pin-project-lite",
+ "smallvec",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "gio-sys"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37566df850baf5e4cb0dfb78af2e4b9898d817ed9263d1090a2df958c64737d2"
+dependencies = [
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "system-deps",
+ "winapi",
+]
+
+[[package]]
+name = "glib"
+version = "0.18.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "233daaf6e83ae6a12a52055f568f9d7cf4671dabb78ff9560ab6da230ce00ee5"
+dependencies = [
+ "bitflags 2.11.0",
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-task",
+ "futures-util",
+ "gio-sys",
+ "glib-macros",
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "memchr",
+ "once_cell",
+ "smallvec",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "glib-macros"
+version = "0.18.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bb0228f477c0900c880fd78c8759b95c7636dbd7842707f49e132378aa2acdc"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro-crate 2.0.2",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "glib-sys"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "063ce2eb6a8d0ea93d2bf8ba1957e78dbab6be1c2220dd3daca57d5a9d869898"
+dependencies = [
+ "libc",
+ "system-deps",
+]
+
+[[package]]
+name = "gobject-sys"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0850127b514d1c4a4654ead6dedadb18198999985908e6ffe4436f53c785ce44"
+dependencies = [
+ "glib-sys",
+ "libc",
+ "system-deps",
+]
+
+[[package]]
+name = "gtk"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd56fb197bfc42bd5d2751f4f017d44ff59fbb58140c6b49f9b3b2bdab08506a"
+dependencies = [
+ "atk",
+ "cairo-rs",
+ "field-offset",
+ "futures-channel",
+ "gdk",
+ "gdk-pixbuf",
+ "gio",
+ "glib",
+ "gtk-sys",
+ "gtk3-macros",
+ "libc",
+ "pango",
+ "pkg-config",
+]
+
+[[package]]
+name = "gtk-sys"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f29a1c21c59553eb7dd40e918be54dccd60c52b049b75119d5d96ce6b624414"
+dependencies = [
+ "atk-sys",
+ "cairo-sys-rs",
+ "gdk-pixbuf-sys",
+ "gdk-sys",
+ "gio-sys",
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "pango-sys",
+ "system-deps",
+]
+
+[[package]]
+name = "gtk3-macros"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ff3c5b21f14f0736fed6dcfc0bfb4225ebf5725f3c0209edeec181e4d73e9d"
+dependencies = [
+ "proc-macro-crate 1.3.1",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "foldhash",
+ "foldhash 0.1.5",
 ]
 
 [[package]]
@@ -196,9 +895,35 @@ checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
 name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
+name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "html5ever"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1054432bae2f14e0061e33d23402fbaa67a921d319d56adc6bcf887ddad1cbc2"
+dependencies = [
+ "log",
+ "markup5ever",
+]
+
+[[package]]
+name = "http"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
+dependencies = [
+ "bytes",
+ "itoa",
+]
 
 [[package]]
 name = "icu_collections"
@@ -327,6 +1052,73 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
+name = "javascriptcore-rs"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca5671e9ffce8ffba57afc24070e906da7fc4b1ba66f2cabebf61bf2ea257fcc"
+dependencies = [
+ "bitflags 1.3.2",
+ "glib",
+ "javascriptcore-rs-sys",
+]
+
+[[package]]
+name = "javascriptcore-rs-sys"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af1be78d14ffa4b75b66df31840478fef72b51f8c2465d4ca7c194da9f7a5124"
+dependencies = [
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "system-deps",
+]
+
+[[package]]
+name = "jni"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+dependencies = [
+ "cesu8",
+ "cfg-if",
+ "combine",
+ "jni-sys 0.3.1",
+ "log",
+ "thiserror 1.0.69",
+ "walkdir",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+dependencies = [
+ "jni-sys 0.4.1",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -339,12 +1131,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
 
 [[package]]
+name = "libdbus-sys"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "328c4789d42200f1eeec05bd86c9c13c7f091d2ba9a6ea35acdf51f31bc0f043"
+dependencies = [
+ "pkg-config",
+]
+
+[[package]]
 name = "libredox"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "libc",
 ]
 
@@ -361,16 +1162,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "markup5ever"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8983d30f2915feeaaab2d6babdd6bc7e9ed1a00b66b5e6d74df19aa9c0e91862"
+dependencies = [
+ "log",
+ "tendril",
+ "web_atoms",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "native-tls"
@@ -390,6 +1220,257 @@ dependencies = [
 ]
 
 [[package]]
+name = "ndk"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3f42e7bbe13d351b6bead8286a43aac9534b82bd3cc43e47037f012ebfd62d4"
+dependencies = [
+ "bitflags 2.11.0",
+ "jni-sys 0.3.1",
+ "log",
+ "ndk-sys",
+ "num_enum",
+ "raw-window-handle",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "ndk-sys"
+version = "0.6.0+11769913"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee6cda3051665f1fb8d9e08fc35c96d5a244fb1be711a03b71118828afc9a873"
+dependencies = [
+ "jni-sys 0.3.1",
+]
+
+[[package]]
+name = "new_debug_unreachable"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
+name = "num-conv"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
+name = "num_enum"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
+dependencies = [
+ "num_enum_derive",
+ "rustversion",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
+dependencies = [
+ "proc-macro-crate 3.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+ "objc2-exception-helper",
+]
+
+[[package]]
+name = "objc2-app-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-cloud-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ad74d880bb43877038da939b7427bba67e9dd42004a18b809ba7d87cee241c"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-data"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b402a653efbb5e82ce4df10683b6b28027616a2715e90009947d50b8dd298fa"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags 2.11.0",
+ "dispatch2",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-core-graphics"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
+dependencies = [
+ "bitflags 2.11.0",
+ "dispatch2",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-io-surface",
+]
+
+[[package]]
+name = "objc2-core-image"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5d563b38d2b97209f8e861173de434bd0214cf020e3423a52624cd1d989f006"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-location"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca347214e24bc973fc025fd0d36ebb179ff30536ed1f80252706db19ee452009"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-text"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cde0dfb48d25d2b4862161a4d5fcc0e3c24367869ad306b0c9ec0073bfed92d"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-exception-helper"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7a1c5fbb72d7735b076bb47b578523aedc40f3c439bea6dfd595c089d79d98a"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "objc2-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-io-surface"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-quartz-core"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-ui-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d87d638e33c06f577498cbcc50491496a3ed4246998a7fbba7ccb98b1e7eab22"
+dependencies = [
+ "bitflags 2.11.0",
+ "block2",
+ "objc2",
+ "objc2-cloud-kit",
+ "objc2-core-data",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-core-image",
+ "objc2-core-location",
+ "objc2-core-text",
+ "objc2-foundation",
+ "objc2-quartz-core",
+ "objc2-user-notifications",
+]
+
+[[package]]
+name = "objc2-user-notifications"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9df9128cbbfef73cda168416ccf7f837b62737d748333bfe9ab71c245d76613e"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-web-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2e5aaab980c433cf470df9d7af96a7b46a9d892d521a2cbbb2f8a4c16751e7f"
+dependencies = [
+ "bitflags 2.11.0",
+ "block2",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-foundation",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -401,9 +1482,9 @@ version = "0.10.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "cfg-if",
- "foreign-types",
+ "foreign-types 0.3.2",
  "libc",
  "once_cell",
  "openssl-macros",
@@ -418,7 +1499,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -446,10 +1527,117 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "pango"
+version = "0.18.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ca27ec1eb0457ab26f3036ea52229edbdb74dee1edd29063f5b9b010e7ebee4"
+dependencies = [
+ "gio",
+ "glib",
+ "libc",
+ "once_cell",
+ "pango-sys",
+]
+
+[[package]]
+name = "pango-sys"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "436737e391a843e5933d6d9aa102cb126d501e815b83601365a948a518555dc5"
+dependencies = [
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "system-deps",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link 0.2.1",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "phf"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
+dependencies = [
+ "phf_macros",
+ "phf_shared",
+ "serde",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49aa7f9d80421bca176ca8dbfebe668cc7a2684708594ec9f3c0db0805d5d6e1"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
+dependencies = [
+ "fastrand",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pkg-config"
@@ -467,13 +1655,78 @@ dependencies = [
 ]
 
 [[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
+name = "precomputed-hash"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
+dependencies = [
+ "once_cell",
+ "toml_edit 0.19.15",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b00f26d3400549137f92511a46ac1cd8ce37cb5598a96d382381458b992a5d24"
+dependencies = [
+ "toml_datetime 0.6.3",
+ "toml_edit 0.20.2",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit 0.25.13+spec-1.1.0",
+]
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
 ]
 
 [[package]]
@@ -501,6 +1754,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
+name = "raw-window-handle"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags 2.11.0",
+]
+
+[[package]]
 name = "redox_users"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -508,7 +1776,22 @@ checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom 0.2.17",
  "libredox",
- "thiserror",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
 ]
 
 [[package]]
@@ -517,11 +1800,26 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustversion"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -530,8 +1828,14 @@ version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "security-framework"
@@ -539,7 +1843,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -554,6 +1858,25 @@ checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
 dependencies = [
  "core-foundation-sys",
  "libc",
+]
+
+[[package]]
+name = "selectors"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5d9c0c92a92d33f08817311cf3f2c29a3538a8240e94a6a3c622ce652d7e00c"
+dependencies = [
+ "bitflags 2.11.0",
+ "cssparser",
+ "derive_more",
+ "log",
+ "new_debug_unreachable",
+ "phf",
+ "phf_codegen",
+ "precomputed-hash",
+ "rustc-hash",
+ "servo_arc",
+ "smallvec",
 ]
 
 [[package]]
@@ -589,7 +1912,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -606,10 +1929,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "servo_arc"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "170fb83ab34de17dc69aa7c67482b22218ddb85da56546f9bd6b929e32a05930"
+dependencies = [
+ "stable_deref_trait",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
@@ -618,16 +1982,87 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
+name = "soup3"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "471f924a40f31251afc77450e781cb26d55c0b650842efafc9c6cbd2f7cc4f9f"
+dependencies = [
+ "futures-channel",
+ "gio",
+ "glib",
+ "libc",
+ "soup3-sys",
+]
+
+[[package]]
+name = "soup3-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ebe8950a680a12f24f15ebe1bf70db7af98ad242d9db43596ad3108aab86c27"
+dependencies = [
+ "gio-sys",
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "system-deps",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "string_cache"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a18596f8c785a729f2819c0f6a7eae6ebeebdfffbfe4214ae6b087f690e31901"
+dependencies = [
+ "new_debug_unreachable",
+ "parking_lot",
+ "phf_shared",
+ "precomputed-hash",
+]
+
+[[package]]
+name = "string_cache_codegen"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "585635e46db231059f76c5849798146164652513eb9e8ab2685939dd90f29b69"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "unicode-ident",
+]
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -642,8 +2077,78 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
+
+[[package]]
+name = "system-deps"
+version = "6.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3e535eb8dded36d55ec13eddacd30dec501792ff23a0b1682c38601b8cf2349"
+dependencies = [
+ "cfg-expr",
+ "heck 0.5.0",
+ "pkg-config",
+ "toml 0.8.2",
+ "version-compare",
+]
+
+[[package]]
+name = "tao"
+version = "0.35.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1c93047acf68669466a34690ac58cca7010bd1b201e1ec86f1fd0a75d3dd4a9"
+dependencies = [
+ "bitflags 2.11.0",
+ "block2",
+ "core-foundation",
+ "core-graphics",
+ "crossbeam-channel",
+ "dbus",
+ "dispatch2",
+ "dlopen2",
+ "dpi",
+ "gdkwayland-sys",
+ "gdkx11-sys",
+ "gtk",
+ "jni",
+ "libc",
+ "log",
+ "ndk",
+ "ndk-sys",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-foundation",
+ "objc2-ui-kit",
+ "once_cell",
+ "parking_lot",
+ "percent-encoding",
+ "raw-window-handle",
+ "tao-macros",
+ "unicode-segmentation",
+ "url",
+ "windows 0.61.3",
+ "windows-core 0.61.2",
+ "windows-version",
+ "x11-dl",
+]
+
+[[package]]
+name = "tao-macros"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4e16beb8b2ac17db28eab8bca40e62dbfbb34c0fcdc6d9826b11b7b5d047dfd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "target-lexicon"
+version = "0.12.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
 name = "tempfile"
@@ -655,7 +2160,25 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tendril"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fed54709c5b3a53d09bb1c113ea4f5ceafd1e772ddcb0030a82e1d56c087b08"
+dependencies = [
+ "new_debug_unreachable",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
 ]
 
 [[package]]
@@ -664,7 +2187,18 @@ version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -675,7 +2209,37 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "time"
+version = "0.3.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e1d5e639ff6bab73cb6885cc7e7b1de96c3f32c68ec55f3952614bec1092244"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
+
+[[package]]
+name = "time-macros"
+version = "0.2.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
+dependencies = [
+ "num-conv",
+ "time-core",
 ]
 
 [[package]]
@@ -698,10 +2262,97 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "185d8ab0dfbb35cf1399a6344d8484209c088f75f8f68230da55d48d95d43e3d"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime 0.6.3",
+ "toml_edit 0.20.2",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.19.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
+dependencies = [
+ "indexmap",
+ "toml_datetime 0.6.3",
+ "winnow 0.5.40",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "396e4d48bbb2b7554c944bde63101b5ae446cff6ec4a24227428f15eb72ef338"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime 0.6.3",
+ "winnow 0.5.40",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.13+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
+dependencies = [
+ "indexmap",
+ "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_parser",
+ "winnow 1.0.4",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow 1.0.4",
+]
+
+[[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-xid"
@@ -747,6 +2398,28 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version-compare"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03c2856837ef78f57382f06b2b8563a2f512f7185d732608fd9176cb3b8edf0e"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
 
 [[package]]
 name = "wasi"
@@ -800,11 +2473,134 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
 ]
+
+[[package]]
+name = "web_atoms"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "075474b12bcb3d2e3d4546580e9de478eeeead668a1761e2a8860c836b7ef297"
+dependencies = [
+ "phf",
+ "phf_codegen",
+ "string_cache",
+ "string_cache_codegen",
+]
+
+[[package]]
+name = "webkit2gtk"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1027150013530fb2eaf806408df88461ae4815a45c541c8975e61d6f2fc4793"
+dependencies = [
+ "bitflags 1.3.2",
+ "cairo-rs",
+ "gdk",
+ "gdk-sys",
+ "gio",
+ "gio-sys",
+ "glib",
+ "glib-sys",
+ "gobject-sys",
+ "gtk",
+ "gtk-sys",
+ "javascriptcore-rs",
+ "libc",
+ "once_cell",
+ "soup3",
+ "webkit2gtk-sys",
+]
+
+[[package]]
+name = "webkit2gtk-sys"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "916a5f65c2ef0dfe12fff695960a2ec3d4565359fdbb2e9943c974e06c734ea5"
+dependencies = [
+ "bitflags 1.3.2",
+ "cairo-sys-rs",
+ "gdk-sys",
+ "gio-sys",
+ "glib-sys",
+ "gobject-sys",
+ "gtk-sys",
+ "javascriptcore-rs-sys",
+ "libc",
+ "pkg-config",
+ "soup3-sys",
+ "system-deps",
+]
+
+[[package]]
+name = "webview2-com"
+version = "0.38.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7130243a7a5b33c54a444e54842e6a9e133de08b5ad7b5861cd8ed9a6a5bc96a"
+dependencies = [
+ "webview2-com-macros",
+ "webview2-com-sys",
+ "windows 0.61.3",
+ "windows-core 0.61.2",
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
+]
+
+[[package]]
+name = "webview2-com-macros"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67a921c1b6914c367b2b823cd4cde6f96beec77d30a939c8199bb377cf9b9b54"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "webview2-com-sys"
+version = "0.38.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "381336cfffd772377d291702245447a5251a2ffa5bad679c99e61bc48bacbf9c"
+dependencies = [
+ "thiserror 2.0.18",
+ "windows 0.61.3",
+ "windows-core 0.61.2",
+]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
@@ -812,8 +2608,30 @@ version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
 dependencies = [
- "windows-core",
- "windows-targets",
+ "windows-core 0.58.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows"
+version = "0.61.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
+dependencies = [
+ "windows-collections",
+ "windows-core 0.61.2",
+ "windows-future",
+ "windows-link 0.1.3",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
+dependencies = [
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -822,11 +2640,35 @@ version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
 dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-result",
- "windows-strings",
- "windows-targets",
+ "windows-implement 0.58.0",
+ "windows-interface 0.58.0",
+ "windows-result 0.2.0",
+ "windows-strings 0.1.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
+dependencies = [
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
+ "windows-strings 0.4.2",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
+dependencies = [
+ "windows-core 0.61.2",
+ "windows-link 0.1.3",
+ "windows-threading",
 ]
 
 [[package]]
@@ -837,7 +2679,18 @@ checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -848,8 +2701,25 @@ checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
 
 [[package]]
 name = "windows-link"
@@ -858,12 +2728,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
+name = "windows-numerics"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
+dependencies = [
+ "windows-core 0.61.2",
+ "windows-link 0.1.3",
+]
+
+[[package]]
 name = "windows-result"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+dependencies = [
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -872,8 +2761,26 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
 dependencies = [
- "windows-result",
- "windows-targets",
+ "windows-result 0.2.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
+dependencies = [
+ "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
 ]
 
 [[package]]
@@ -882,7 +2789,22 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -891,15 +2813,39 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
  "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
+
+[[package]]
+name = "windows-threading"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
+dependencies = [
+ "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-version"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4060a1da109b9d0326b7262c8e12c84df67cc0dbc9e33cf49e01ccc2eb63631"
+dependencies = [
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -909,9 +2855,21 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -927,9 +2885,21 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -939,9 +2909,21 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -950,12 +2932,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
+name = "winnow"
+version = "0.5.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "winres"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b68db261ef59e9e52806f688020631e987592bd83619edccda9c47d42cde4f6c"
 dependencies = [
- "toml",
+ "toml 0.5.11",
 ]
 
 [[package]]
@@ -974,7 +2974,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
 dependencies = [
  "anyhow",
- "heck",
+ "heck 0.5.0",
  "wit-parser",
 ]
 
@@ -985,10 +2985,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
- "heck",
+ "heck 0.5.0",
  "indexmap",
  "prettyplease",
- "syn",
+ "syn 2.0.117",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -1004,7 +3004,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -1016,7 +3016,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags",
+ "bitflags 2.11.0",
  "indexmap",
  "log",
  "serde",
@@ -1053,6 +3053,71 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
+name = "wry"
+version = "0.55.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "186f9871daa55fd9c016578b810d149de58367113db7fb72b462d2323ce19514"
+dependencies = [
+ "base64",
+ "block2",
+ "cookie",
+ "crossbeam-channel",
+ "dirs",
+ "dom_query",
+ "dpi",
+ "dunce",
+ "gdkx11",
+ "gtk",
+ "http",
+ "javascriptcore-rs",
+ "jni",
+ "libc",
+ "ndk",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "objc2-ui-kit",
+ "objc2-web-kit",
+ "once_cell",
+ "percent-encoding",
+ "raw-window-handle",
+ "sha2",
+ "soup3",
+ "tao-macros",
+ "thiserror 2.0.18",
+ "url",
+ "webkit2gtk",
+ "webkit2gtk-sys",
+ "webview2-com",
+ "windows 0.61.3",
+ "windows-core 0.61.2",
+ "windows-version",
+ "x11-dl",
+]
+
+[[package]]
+name = "x11"
+version = "2.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "502da5464ccd04011667b11c435cb992822c2c0dbde1770c988480d312a0db2e"
+dependencies = [
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
+name = "x11-dl"
+version = "2.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38735924fedd5314a6e548792904ed8c6de6636285cb9fec04d5b1db85c1516f"
+dependencies = [
+ "libc",
+ "once_cell",
+ "pkg-config",
+]
+
+[[package]]
 name = "yoke"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1071,7 +3136,7 @@ checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -1092,7 +3157,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -1126,7 +3191,7 @@ checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,12 +16,41 @@ InternalName = "ClaudeCodeUsageMonitor"
 Comments = "https://codezeno.com.au"
 LegalCopyright = "Copyright (C) 2026 Code Zeno Pty Ltd"
 
+[[bin]]
+name = "claude-code-usage-monitor"
+path = "src/main.rs"
+
+[[bin]]
+name = "ollama-login-helper"
+path = "src/ollama_login_helper.rs"
+required-features = ["ollama-login-webview"]
+
 [dependencies]
 ureq = { version = "2", default-features = false, features = ["native-tls", "json", "proxy-from-env"] }
 native-tls = "0.2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 dirs = "6"
+
+[features]
+# Pulls in wry + tao for an embedded WebView2 login window. Off by default
+# because the native deps add ~6 MB to the release binary. Enable with:
+#   cargo build --release --features ollama-login-webview
+# Then right-click the tray icon → "Log in to Ollama…" to capture fresh
+# cookies via CoreWebView2.CookieManager.GetCookiesAsync().
+default = []
+ollama-login-webview = ["dep:wry", "dep:tao"]
+
+[dependencies.wry]
+version = "0.55"
+optional = true
+# On Windows: uses WebView2 via Edge automatically (no extra feature needed).
+# On Linux: requires `linux-body` (webkit2gtk v2_40).
+# We only target Windows for the tray, so default features suffice.
+
+[dependencies.tao]
+version = "0.35"
+optional = true
 
 [dependencies.windows]
 version = "0.58"

--- a/src/localization/dutch.rs
+++ b/src/localization/dutch.rs
@@ -46,9 +46,7 @@ pub(super) const STRINGS: Strings = Strings {
     antigravity_token_expired_body: "Open Antigravity en meld je opnieuw aan. Ververs of herstart de app daarna.",
     codex_window_title: "Codex-gebruiksmonitor",
     antigravity_window_title: "Antigravity-gebruiksmonitor",
-    minimax_model: "MiniMax",
     ollama_model: "Ollama",
-    minimax_window_title: "MiniMax-gebruiksmonitor",
     ollama_window_title: "Ollama-gebruiksmonitor",
     second_suffix: "s",
 };

--- a/src/localization/dutch.rs
+++ b/src/localization/dutch.rs
@@ -48,5 +48,7 @@ pub(super) const STRINGS: Strings = Strings {
     antigravity_window_title: "Antigravity-gebruiksmonitor",
     ollama_model: "Ollama",
     ollama_window_title: "Ollama-gebruiksmonitor",
+    ollama_token_expired_title: "Ollama-authenticatiefout",
+    ollama_token_expired_body: "Gebruik Models -> 'Inloggen bij Ollama...' of zet OLLAMA_CLOUD_SESSION, en vernieuw daarna.",
     second_suffix: "s",
 };

--- a/src/localization/dutch.rs
+++ b/src/localization/dutch.rs
@@ -46,5 +46,9 @@ pub(super) const STRINGS: Strings = Strings {
     antigravity_token_expired_body: "Open Antigravity en meld je opnieuw aan. Ververs of herstart de app daarna.",
     codex_window_title: "Codex-gebruiksmonitor",
     antigravity_window_title: "Antigravity-gebruiksmonitor",
+    minimax_model: "MiniMax",
+    ollama_model: "Ollama",
+    minimax_window_title: "MiniMax-gebruiksmonitor",
+    ollama_window_title: "Ollama-gebruiksmonitor",
     second_suffix: "s",
 };

--- a/src/localization/english.rs
+++ b/src/localization/english.rs
@@ -46,9 +46,7 @@ pub(super) const STRINGS: Strings = Strings {
     antigravity_token_expired_body: "Open Antigravity and sign in again. After that, refresh or restart this app.",
     codex_window_title: "Codex Usage Monitor",
     antigravity_window_title: "Antigravity Usage Monitor",
-    minimax_model: "MiniMax",
     ollama_model: "Ollama",
-    minimax_window_title: "MiniMax Usage Monitor",
     ollama_window_title: "Ollama Usage Monitor",
     second_suffix: "s",
 };

--- a/src/localization/english.rs
+++ b/src/localization/english.rs
@@ -46,5 +46,9 @@ pub(super) const STRINGS: Strings = Strings {
     antigravity_token_expired_body: "Open Antigravity and sign in again. After that, refresh or restart this app.",
     codex_window_title: "Codex Usage Monitor",
     antigravity_window_title: "Antigravity Usage Monitor",
+    minimax_model: "MiniMax",
+    ollama_model: "Ollama",
+    minimax_window_title: "MiniMax Usage Monitor",
+    ollama_window_title: "Ollama Usage Monitor",
     second_suffix: "s",
 };

--- a/src/localization/english.rs
+++ b/src/localization/english.rs
@@ -48,5 +48,7 @@ pub(super) const STRINGS: Strings = Strings {
     antigravity_window_title: "Antigravity Usage Monitor",
     ollama_model: "Ollama",
     ollama_window_title: "Ollama Usage Monitor",
+    ollama_token_expired_title: "Ollama Auth Error",
+    ollama_token_expired_body: "Use Models -> 'Log in to Ollama...' or set OLLAMA_CLOUD_SESSION, then refresh.",
     second_suffix: "s",
 };

--- a/src/localization/french.rs
+++ b/src/localization/french.rs
@@ -46,5 +46,9 @@ pub(super) const STRINGS: Strings = Strings {
     antigravity_token_expired_body: "Ouvrez Antigravity et reconnectez-vous. Ensuite, actualisez ou redemarrez cette application.",
     codex_window_title: "Moniteur d'utilisation Codex",
     antigravity_window_title: "Moniteur d'utilisation Antigravity",
+    minimax_model: "MiniMax",
+    ollama_model: "Ollama",
+    minimax_window_title: "Moniteur d'utilisation MiniMax",
+    ollama_window_title: "Moniteur d'utilisation Ollama",
     second_suffix: "s",
 };

--- a/src/localization/french.rs
+++ b/src/localization/french.rs
@@ -48,5 +48,7 @@ pub(super) const STRINGS: Strings = Strings {
     antigravity_window_title: "Moniteur d'utilisation Antigravity",
     ollama_model: "Ollama",
     ollama_window_title: "Moniteur d'utilisation Ollama",
+    ollama_token_expired_title: "Erreur d'authentification Ollama",
+    ollama_token_expired_body: "Utilisez Modeles -> 'Se connecter a Ollama...' ou definissez OLLAMA_CLOUD_SESSION, puis actualisez.",
     second_suffix: "s",
 };

--- a/src/localization/french.rs
+++ b/src/localization/french.rs
@@ -46,9 +46,7 @@ pub(super) const STRINGS: Strings = Strings {
     antigravity_token_expired_body: "Ouvrez Antigravity et reconnectez-vous. Ensuite, actualisez ou redemarrez cette application.",
     codex_window_title: "Moniteur d'utilisation Codex",
     antigravity_window_title: "Moniteur d'utilisation Antigravity",
-    minimax_model: "MiniMax",
     ollama_model: "Ollama",
-    minimax_window_title: "Moniteur d'utilisation MiniMax",
     ollama_window_title: "Moniteur d'utilisation Ollama",
     second_suffix: "s",
 };

--- a/src/localization/german.rs
+++ b/src/localization/german.rs
@@ -46,5 +46,9 @@ pub(super) const STRINGS: Strings = Strings {
     antigravity_token_expired_body: "Offnen Sie Antigravity und melden Sie sich erneut an. Aktualisieren oder starten Sie diese App anschliessend neu.",
     codex_window_title: "Codex-Nutzungsmonitor",
     antigravity_window_title: "Antigravity-Nutzungsmonitor",
+    minimax_model: "MiniMax",
+    ollama_model: "Ollama",
+    minimax_window_title: "MiniMax-Nutzungsmonitor",
+    ollama_window_title: "Ollama-Nutzungsmonitor",
     second_suffix: "s",
 };

--- a/src/localization/german.rs
+++ b/src/localization/german.rs
@@ -46,9 +46,7 @@ pub(super) const STRINGS: Strings = Strings {
     antigravity_token_expired_body: "Offnen Sie Antigravity und melden Sie sich erneut an. Aktualisieren oder starten Sie diese App anschliessend neu.",
     codex_window_title: "Codex-Nutzungsmonitor",
     antigravity_window_title: "Antigravity-Nutzungsmonitor",
-    minimax_model: "MiniMax",
     ollama_model: "Ollama",
-    minimax_window_title: "MiniMax-Nutzungsmonitor",
     ollama_window_title: "Ollama-Nutzungsmonitor",
     second_suffix: "s",
 };

--- a/src/localization/german.rs
+++ b/src/localization/german.rs
@@ -48,5 +48,7 @@ pub(super) const STRINGS: Strings = Strings {
     antigravity_window_title: "Antigravity-Nutzungsmonitor",
     ollama_model: "Ollama",
     ollama_window_title: "Ollama-Nutzungsmonitor",
+    ollama_token_expired_title: "Ollama-Authentifizierungsfehler",
+    ollama_token_expired_body: "Nutzen Sie Modelle -> 'Bei Ollama anmelden...' oder setzen Sie OLLAMA_CLOUD_SESSION und aktualisieren Sie.",
     second_suffix: "s",
 };

--- a/src/localization/japanese.rs
+++ b/src/localization/japanese.rs
@@ -46,5 +46,9 @@ pub(super) const STRINGS: Strings = Strings {
     antigravity_token_expired_body: "Antigravity を開いて再度サインインしてください。その後、このアプリを更新するか再起動してください。",
     codex_window_title: "Codex 使用量モニター",
     antigravity_window_title: "Antigravity 使用量モニター",
+    minimax_model: "MiniMax",
+    ollama_model: "Ollama",
+    minimax_window_title: "MiniMax 使用量モニター",
+    ollama_window_title: "Ollama 使用量モニター",
     second_suffix: "秒",
 };

--- a/src/localization/japanese.rs
+++ b/src/localization/japanese.rs
@@ -46,9 +46,7 @@ pub(super) const STRINGS: Strings = Strings {
     antigravity_token_expired_body: "Antigravity を開いて再度サインインしてください。その後、このアプリを更新するか再起動してください。",
     codex_window_title: "Codex 使用量モニター",
     antigravity_window_title: "Antigravity 使用量モニター",
-    minimax_model: "MiniMax",
     ollama_model: "Ollama",
-    minimax_window_title: "MiniMax 使用量モニター",
     ollama_window_title: "Ollama 使用量モニター",
     second_suffix: "秒",
 };

--- a/src/localization/japanese.rs
+++ b/src/localization/japanese.rs
@@ -48,5 +48,7 @@ pub(super) const STRINGS: Strings = Strings {
     antigravity_window_title: "Antigravity 使用量モニター",
     ollama_model: "Ollama",
     ollama_window_title: "Ollama 使用量モニター",
+    ollama_token_expired_title: "Ollama 認証エラー",
+    ollama_token_expired_body: "Models -> 'Ollama にログイン...' を使うか OLLAMA_CLOUD_SESSION を設定してから更新してください。",
     second_suffix: "秒",
 };

--- a/src/localization/korean.rs
+++ b/src/localization/korean.rs
@@ -48,5 +48,7 @@ pub(super) const STRINGS: Strings = Strings {
     antigravity_window_title: "Antigravity 사용량 모니터",
     ollama_model: "Ollama",
     ollama_window_title: "Ollama 사용량 모니터",
+    ollama_token_expired_title: "Ollama 인증 오류",
+    ollama_token_expired_body: "Models -> 'Ollama에 로그인...'을 사용하거나 OLLAMA_CLOUD_SESSION을 설정한 뒤 새로 고치세요.",
     second_suffix: "초",
 };

--- a/src/localization/korean.rs
+++ b/src/localization/korean.rs
@@ -46,5 +46,9 @@ pub(super) const STRINGS: Strings = Strings {
     antigravity_token_expired_body: "Antigravity를 열고 다시 로그인하세요. 그런 다음 이 앱을 새로 고치거나 다시 시작하세요.",
     codex_window_title: "Codex 사용량 모니터",
     antigravity_window_title: "Antigravity 사용량 모니터",
+    minimax_model: "MiniMax",
+    ollama_model: "Ollama",
+    minimax_window_title: "MiniMax 사용량 모니터",
+    ollama_window_title: "Ollama 사용량 모니터",
     second_suffix: "초",
 };

--- a/src/localization/korean.rs
+++ b/src/localization/korean.rs
@@ -46,9 +46,7 @@ pub(super) const STRINGS: Strings = Strings {
     antigravity_token_expired_body: "Antigravity를 열고 다시 로그인하세요. 그런 다음 이 앱을 새로 고치거나 다시 시작하세요.",
     codex_window_title: "Codex 사용량 모니터",
     antigravity_window_title: "Antigravity 사용량 모니터",
-    minimax_model: "MiniMax",
     ollama_model: "Ollama",
-    minimax_window_title: "MiniMax 사용량 모니터",
     ollama_window_title: "Ollama 사용량 모니터",
     second_suffix: "초",
 };

--- a/src/localization/mod.rs
+++ b/src/localization/mod.rs
@@ -191,6 +191,8 @@ pub struct Strings {
         pub antigravity_window_title: &'static str,
         pub ollama_model: &'static str,
         pub ollama_window_title: &'static str,
+    pub ollama_token_expired_title: &'static str,
+    pub ollama_token_expired_body: &'static str,
     }
 
 pub fn resolve_language(language_override: Option<LanguageId>) -> LanguageId {

--- a/src/localization/mod.rs
+++ b/src/localization/mod.rs
@@ -186,14 +186,12 @@ pub struct Strings {
     pub codex_token_expired_title: &'static str,
     pub codex_token_expired_body: &'static str,
     pub antigravity_token_expired_title: &'static str,
-    pub antigravity_token_expired_body: &'static str,
-    pub codex_window_title: &'static str,
-    pub antigravity_window_title: &'static str,
-    pub minimax_model: &'static str,
-    pub ollama_model: &'static str,
-    pub minimax_window_title: &'static str,
-    pub ollama_window_title: &'static str,
-}
+        pub antigravity_token_expired_body: &'static str,
+        pub codex_window_title: &'static str,
+        pub antigravity_window_title: &'static str,
+        pub ollama_model: &'static str,
+        pub ollama_window_title: &'static str,
+    }
 
 pub fn resolve_language(language_override: Option<LanguageId>) -> LanguageId {
     language_override.unwrap_or_else(detect_system_language)

--- a/src/localization/mod.rs
+++ b/src/localization/mod.rs
@@ -189,6 +189,10 @@ pub struct Strings {
     pub antigravity_token_expired_body: &'static str,
     pub codex_window_title: &'static str,
     pub antigravity_window_title: &'static str,
+    pub minimax_model: &'static str,
+    pub ollama_model: &'static str,
+    pub minimax_window_title: &'static str,
+    pub ollama_window_title: &'static str,
 }
 
 pub fn resolve_language(language_override: Option<LanguageId>) -> LanguageId {

--- a/src/localization/portuguese_brazil.rs
+++ b/src/localization/portuguese_brazil.rs
@@ -49,4 +49,6 @@ pub(super) const STRINGS: Strings = Strings {
     antigravity_window_title: "Monitor de uso de Antigravity",
     ollama_model: "Ollama",
     ollama_window_title: "Monitor de uso do Ollama",
+    ollama_token_expired_title: "Erro de Autenticacao do Ollama",
+    ollama_token_expired_body: "Use Models -> 'Entrar no Ollama...' ou defina OLLAMA_CLOUD_SESSION e atualize.",
 };

--- a/src/localization/portuguese_brazil.rs
+++ b/src/localization/portuguese_brazil.rs
@@ -46,5 +46,9 @@ pub(super) const STRINGS: Strings = Strings {
     antigravity_token_expired_title: "Erro de Autenticação do Antigravity",
     antigravity_token_expired_body: "Abra o Antigravity e entre novamente. Depois disso, atualize ou reinicie este aplicativo.",
     codex_window_title: "Monitor de uso do Codex",
-    antigravity_window_title: "Monitor de uso do Antigravity",
+    antigravity_window_title: "Monitor de uso de Antigravity",
+    minimax_model: "MiniMax",
+    ollama_model: "Ollama",
+    minimax_window_title: "Monitor de uso do MiniMax",
+    ollama_window_title: "Monitor de uso do Ollama",
 };

--- a/src/localization/portuguese_brazil.rs
+++ b/src/localization/portuguese_brazil.rs
@@ -47,8 +47,6 @@ pub(super) const STRINGS: Strings = Strings {
     antigravity_token_expired_body: "Abra o Antigravity e entre novamente. Depois disso, atualize ou reinicie este aplicativo.",
     codex_window_title: "Monitor de uso do Codex",
     antigravity_window_title: "Monitor de uso de Antigravity",
-    minimax_model: "MiniMax",
     ollama_model: "Ollama",
-    minimax_window_title: "Monitor de uso do MiniMax",
     ollama_window_title: "Monitor de uso do Ollama",
 };

--- a/src/localization/russian.rs
+++ b/src/localization/russian.rs
@@ -47,4 +47,8 @@ pub(super) const STRINGS: Strings = Strings {
     antigravity_token_expired_body: "Откройте Antigravity и войдите снова. После этого обновите или перезапустите приложение.",
     codex_window_title: "Монитор использования Codex",
     antigravity_window_title: "Монитор использования Antigravity",
+    minimax_model: "MiniMax",
+    ollama_model: "Ollama",
+    minimax_window_title: "Монитор использования MiniMax",
+    ollama_window_title: "Монитор использования Ollama",
 };

--- a/src/localization/russian.rs
+++ b/src/localization/russian.rs
@@ -49,4 +49,6 @@ pub(super) const STRINGS: Strings = Strings {
     antigravity_window_title: "Монитор использования Antigravity",
     ollama_model: "Ollama",
     ollama_window_title: "Монитор использования Ollama",
+    ollama_token_expired_title: "Ошибка авторизации Ollama",
+    ollama_token_expired_body: "Используйте Models -> 'Войти в Ollama...' или задайте OLLAMA_CLOUD_SESSION, затем обновите.",
 };

--- a/src/localization/russian.rs
+++ b/src/localization/russian.rs
@@ -47,8 +47,6 @@ pub(super) const STRINGS: Strings = Strings {
     antigravity_token_expired_body: "Откройте Antigravity и войдите снова. После этого обновите или перезапустите приложение.",
     codex_window_title: "Монитор использования Codex",
     antigravity_window_title: "Монитор использования Antigravity",
-    minimax_model: "MiniMax",
     ollama_model: "Ollama",
-    minimax_window_title: "Монитор использования MiniMax",
     ollama_window_title: "Монитор использования Ollama",
 };

--- a/src/localization/simplified_chinese.rs
+++ b/src/localization/simplified_chinese.rs
@@ -48,5 +48,7 @@ pub(super) const STRINGS: Strings = Strings {
     antigravity_window_title: "Antigravity 使用量监控",
     ollama_model: "Ollama",
     ollama_window_title: "Ollama 使用量监控",
+    ollama_token_expired_title: "Ollama 验证错误",
+    ollama_token_expired_body: "请使用 Models -> '登录 Ollama...' 或设置 OLLAMA_CLOUD_SESSION，然后刷新。",
     second_suffix: "秒",
 };

--- a/src/localization/simplified_chinese.rs
+++ b/src/localization/simplified_chinese.rs
@@ -46,9 +46,7 @@ pub(super) const STRINGS: Strings = Strings {
     antigravity_token_expired_body: "请打开 Antigravity 并重新登录。完成后，请刷新或重新启动此应用程序。",
     codex_window_title: "Codex 使用量监控",
     antigravity_window_title: "Antigravity 使用量监控",
-    minimax_model: "MiniMax",
     ollama_model: "Ollama",
-    minimax_window_title: "MiniMax 使用量监控",
     ollama_window_title: "Ollama 使用量监控",
     second_suffix: "秒",
 };

--- a/src/localization/simplified_chinese.rs
+++ b/src/localization/simplified_chinese.rs
@@ -46,5 +46,9 @@ pub(super) const STRINGS: Strings = Strings {
     antigravity_token_expired_body: "请打开 Antigravity 并重新登录。完成后，请刷新或重新启动此应用程序。",
     codex_window_title: "Codex 使用量监控",
     antigravity_window_title: "Antigravity 使用量监控",
+    minimax_model: "MiniMax",
+    ollama_model: "Ollama",
+    minimax_window_title: "MiniMax 使用量监控",
+    ollama_window_title: "Ollama 使用量监控",
     second_suffix: "秒",
 };

--- a/src/localization/spanish.rs
+++ b/src/localization/spanish.rs
@@ -46,9 +46,7 @@ pub(super) const STRINGS: Strings = Strings {
     antigravity_token_expired_body: "Abre Antigravity e inicia sesion otra vez. Despues, actualiza o reinicia esta aplicacion.",
     codex_window_title: "Monitor de uso de Codex",
     antigravity_window_title: "Monitor de uso de Antigravity",
-    minimax_model: "MiniMax",
     ollama_model: "Ollama",
-    minimax_window_title: "Monitor de uso de MiniMax",
     ollama_window_title: "Monitor de uso de Ollama",
     second_suffix: "s",
 };

--- a/src/localization/spanish.rs
+++ b/src/localization/spanish.rs
@@ -48,5 +48,7 @@ pub(super) const STRINGS: Strings = Strings {
     antigravity_window_title: "Monitor de uso de Antigravity",
     ollama_model: "Ollama",
     ollama_window_title: "Monitor de uso de Ollama",
+    ollama_token_expired_title: "Error de autenticacion de Ollama",
+    ollama_token_expired_body: "Usa Models -> 'Iniciar sesion en Ollama...' o define OLLAMA_CLOUD_SESSION y luego actualiza.",
     second_suffix: "s",
 };

--- a/src/localization/spanish.rs
+++ b/src/localization/spanish.rs
@@ -46,5 +46,9 @@ pub(super) const STRINGS: Strings = Strings {
     antigravity_token_expired_body: "Abre Antigravity e inicia sesion otra vez. Despues, actualiza o reinicia esta aplicacion.",
     codex_window_title: "Monitor de uso de Codex",
     antigravity_window_title: "Monitor de uso de Antigravity",
+    minimax_model: "MiniMax",
+    ollama_model: "Ollama",
+    minimax_window_title: "Monitor de uso de MiniMax",
+    ollama_window_title: "Monitor de uso de Ollama",
     second_suffix: "s",
 };

--- a/src/localization/traditional_chinese.rs
+++ b/src/localization/traditional_chinese.rs
@@ -46,9 +46,7 @@ pub(super) const STRINGS: Strings = Strings {
     antigravity_token_expired_body: "請開啟 Antigravity 並重新登入。完成後，請重新整理或重新啟動此應用程式。",
     codex_window_title: "Codex 使用量監控",
     antigravity_window_title: "Antigravity 使用量監控",
-    minimax_model: "MiniMax",
     ollama_model: "Ollama",
-    minimax_window_title: "MiniMax 使用量監控",
     ollama_window_title: "Ollama 使用量監控",
     second_suffix: "秒",
 };

--- a/src/localization/traditional_chinese.rs
+++ b/src/localization/traditional_chinese.rs
@@ -46,5 +46,9 @@ pub(super) const STRINGS: Strings = Strings {
     antigravity_token_expired_body: "請開啟 Antigravity 並重新登入。完成後，請重新整理或重新啟動此應用程式。",
     codex_window_title: "Codex 使用量監控",
     antigravity_window_title: "Antigravity 使用量監控",
+    minimax_model: "MiniMax",
+    ollama_model: "Ollama",
+    minimax_window_title: "MiniMax 使用量監控",
+    ollama_window_title: "Ollama 使用量監控",
     second_suffix: "秒",
 };

--- a/src/localization/traditional_chinese.rs
+++ b/src/localization/traditional_chinese.rs
@@ -48,5 +48,7 @@ pub(super) const STRINGS: Strings = Strings {
     antigravity_window_title: "Antigravity 使用量監控",
     ollama_model: "Ollama",
     ollama_window_title: "Ollama 使用量監控",
+    ollama_token_expired_title: "Ollama 驗證錯誤",
+    ollama_token_expired_body: "請使用 Models -> '登入 Ollama...' 或設定 OLLAMA_CLOUD_SESSION，然後重新整理。",
     second_suffix: "秒",
 };

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,8 @@ mod diagnose;
 mod localization;
 mod models;
 mod native_interop;
+#[cfg(feature = "ollama-login-webview")]
+mod ollama_login;
 mod poller;
 mod theme;
 mod tray_icon;

--- a/src/models.rs
+++ b/src/models.rs
@@ -17,6 +17,8 @@ pub struct AppUsageData {
     pub claude_code: Option<UsageData>,
     pub codex: Option<UsageData>,
     pub antigravity: Option<UsageData>,
-    pub minimax: Option<UsageData>,
+    /// Ollama Cloud plan-tier usage. Polled from ollama.com/settings
+    /// using the user's browser-captured session cookie. `None` when the
+    /// cookie is missing or the poll fails (e.g. session expired).
     pub ollama: Option<UsageData>,
 }

--- a/src/models.rs
+++ b/src/models.rs
@@ -17,4 +17,6 @@ pub struct AppUsageData {
     pub claude_code: Option<UsageData>,
     pub codex: Option<UsageData>,
     pub antigravity: Option<UsageData>,
+    pub minimax: Option<UsageData>,
+    pub ollama: Option<UsageData>,
 }

--- a/src/ollama_login.rs
+++ b/src/ollama_login.rs
@@ -1,0 +1,85 @@
+//! Ollama Cloud login via embedded WebView2 (wry).
+//!
+//! # Why this exists
+//!
+//! ollama.com's auth is WorkOS-hosted. A raw `Cookie:` header from any
+//! non-Chrome process fails the session-binding check → 303 to
+//! `signin.ollama.com`. There is no public Ollama Cloud usage API. The
+//! proven workaround on Windows is to log in inside a real browser context
+//! and read the cookies that browser got from WorkOS.
+//!
+//! # How it runs
+//!
+//! The tray spawns a **separate helper process** (`ollama-login-helper.exe`)
+//! that opens a WebView2 window pointing at `https://ollama.com/signin`.
+//! The user completes WorkOS auth in that window. When the helper detects
+//! the user has landed on `/settings` (or new cookies have been set), it
+//! writes them to
+//! `%LOCALAPPDATA%\ClaudeCodeUsageMonitor\ollama_session_cookie.txt` and
+//! exits. The tray picks up the cookies on the next poll cycle.
+//!
+//! A separate process is required because tao's `EventLoop::run()` on
+//! Windows MUST own the Win32 message pump. Running it inside the tray's
+//! `DispatchMessageW` handler doesn't work — the event loop starves and
+//! WebView2 never paints or navigates.
+//!
+//! # Feature gate
+//!
+//! Feature-gated behind `ollama-login-webview` so the default build doesn't
+//! pull wry/tao. Enable with:
+//!     `cargo build --release --features ollama-login-webview`
+
+use crate::diagnose;
+
+/// Spawn the standalone `ollama-login-helper.exe` as a separate process.
+/// This is the ONLY way to make wry/tao work on Windows: the event loop
+/// must own the Win32 message pump, which is impossible when running
+/// inside the tray's `DispatchMessageW` handler.
+///
+/// The helper binary opens a WebView2 window, the user completes auth,
+/// the helper captures cookies, writes them to the cookie file, and exits.
+/// The tray picks up the cookies on the next poll cycle.
+///
+/// This function returns immediately (non-blocking). The tray stays
+/// responsive while the helper runs.
+pub fn run_login_blocking() {
+    diagnose::log("ollama-login-webview: spawning ollama-login-helper.exe");
+
+    let exe_dir = std::env::current_exe()
+        .ok()
+        .and_then(|p| p.parent().map(|d| d.to_path_buf()));
+
+    let helper_exe = exe_dir
+        .as_ref()
+        .map(|d| d.join("ollama-login-helper.exe"))
+        .unwrap_or_else(|| std::path::PathBuf::from("ollama-login-helper.exe"));
+
+    diagnose::log(format!(
+        "ollama-login-webview: helper path = {}",
+        helper_exe.display()
+    ));
+
+    if !helper_exe.exists() {
+        diagnose::log(format!(
+            "ollama-login-webview: helper exe NOT FOUND at {}",
+            helper_exe.display()
+        ));
+        return;
+    }
+
+    match std::process::Command::new(&helper_exe)
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .spawn()
+    {
+        Ok(child) => {
+            diagnose::log(format!(
+                "ollama-login-webview: helper spawned PID={}",
+                child.id()
+            ));
+        }
+        Err(e) => {
+            diagnose::log_error("ollama-login-webview: failed to spawn helper", e);
+        }
+    }
+}

--- a/src/ollama_login_helper.rs
+++ b/src/ollama_login_helper.rs
@@ -15,6 +15,8 @@
 //!   2 = webview init error
 //!   3 = cookie write error
 
+#![windows_subsystem = "windows"]
+
 use std::path::PathBuf;
 use std::time::{Duration, Instant};
 
@@ -239,6 +241,9 @@ fn write_cookie_file(cookies: &[Cookie]) -> std::io::Result<()> {
         std::fs::create_dir_all(parent)?;
     }
     let header = build_cookie_header(cookies);
+    // Intentionally plaintext under the current user's LOCALAPPDATA profile —
+    // same trust boundary as OLLAMA_CLOUD_SESSION / ~/.claude/settings.json.
+    // Encrypting only this file wouldn't cover those override paths.
     std::fs::write(&path, header.as_bytes())?;
     println!(
         "ollama-login-helper: wrote {} bytes to {}",

--- a/src/ollama_login_helper.rs
+++ b/src/ollama_login_helper.rs
@@ -1,0 +1,263 @@
+//! Standalone Ollama login helper binary.
+//!
+//! Runs as a separate process (`ollama-login-helper.exe`) so the wry/tao
+//! event loop owns the Win32 message pump. The tray spawns this binary,
+//! the user completes WorkOS auth in the WebView window, this binary
+//! captures the cookies, writes them to the cookie file, and exits.
+//! The tray then picks up the cookies on the next poll cycle.
+//!
+//! Usage:
+//!   ollama-login-helper.exe
+//!
+//! Exit codes:
+//!   0 = cookies captured and written
+//!   1 = timeout (no login within 180s)
+//!   2 = webview init error
+//!   3 = cookie write error
+
+use std::path::PathBuf;
+use std::time::{Duration, Instant};
+
+const SIGNIN_URL: &str = "https://ollama.com/signin";
+const SETTINGS_PATH: &str = "/settings";
+const POLL_INTERVAL: Duration = Duration::from_millis(750);
+const MAX_RUNTIME: Duration = Duration::from_secs(180);
+const COOKIE_FILE: &str = "ollama_session_cookie.txt";
+const LOGIN_DONE_MARKER: &str = "ollama_login_done.marker";
+
+fn main() {
+    println!("ollama-login-helper: starting (PID={})", std::process::id());
+
+    let exit_code = run_webview_login();
+    std::process::exit(exit_code);
+}
+
+fn run_webview_login() -> i32 {
+    use tao::dpi::{LogicalPosition, LogicalSize};
+    use tao::event::{Event, StartCause, WindowEvent};
+    use tao::event_loop::{ControlFlow, EventLoopBuilder};
+    use tao::window::WindowBuilder;
+    use wry::{WebContext, WebViewBuilder};
+
+    let event_loop = EventLoopBuilder::new().build();
+
+    let window = match WindowBuilder::new()
+        .with_title("Log in to Ollama — claude-code-usage-monitor")
+        .with_inner_size(LogicalSize::new(520.0, 760.0))
+        .with_position(LogicalPosition::new(100.0, 100.0))
+        .with_visible(true)
+        .build(&event_loop)
+    {
+        Ok(w) => w,
+        Err(e) => {
+            eprintln!("ollama-login-helper: window build failed: {e}");
+            return 2;
+        }
+    };
+
+    let data_dir = cookie_file_path()
+        .map(|p| p.parent().unwrap().join("webview2_data"))
+        .unwrap_or_else(|_| PathBuf::from("webview2_data"));
+    let mut web_context = WebContext::new(Some(data_dir));
+
+    let webview = match WebViewBuilder::new_with_web_context(&mut web_context)
+        .with_url(SIGNIN_URL)
+        .build(&window)
+    {
+        Ok(w) => w,
+        Err(e) => {
+            eprintln!("ollama-login-helper: webview build failed: {e}");
+            return 2;
+        }
+    };
+    println!("ollama-login-helper: webview built, entering event loop");
+
+    let started = Instant::now();
+    let mut last_poll: Option<Instant> = None;
+    let mut sent = false;
+    let mut exit_code: i32 = 1; // timeout by default
+    let mut initial_cookie_count: Option<usize> = None;
+
+    event_loop.run(move |event, _, control_flow| {
+        *control_flow = ControlFlow::Wait;
+
+        match event {
+            Event::NewEvents(StartCause::Init) => {
+                println!("ollama-login-helper: event loop init");
+            }
+            Event::WindowEvent {
+                event: WindowEvent::CloseRequested,
+                ..
+            } => {
+                println!("ollama-login-helper: window closed");
+                *control_flow = ControlFlow::Exit;
+            }
+            _ => {}
+        }
+
+        let now = Instant::now();
+        let due = last_poll
+            .map(|t| now.duration_since(t) >= POLL_INTERVAL)
+            .unwrap_or(true);
+        if due {
+            last_poll = Some(now);
+
+            let url = webview.url().unwrap_or_default();
+            let cookies = read_cookies(&webview);
+            let ollama_cookie_count = cookies.len();
+
+            // Track initial cookie count (from stale/previous session)
+            if initial_cookie_count.is_none() {
+                initial_cookie_count = Some(ollama_cookie_count);
+                println!(
+                    "ollama-login-helper: initial cookies={}",
+                    ollama_cookie_count
+                );
+            }
+
+            // Also try to get the real URL via JS (webview.url() on Windows
+            // can return about:blank even after navigation has completed)
+            let real_url = if url == "about:blank" {
+                // Use evaluate_script to get window.location.href
+                // This is a synchronous JS eval that returns the real URL
+                match webview.evaluate_script("window.location.href") {
+                    Ok(_) => {
+                        // evaluate_script doesn't return a value in wry 0.55,
+                        // but the navigation handler will have fired.
+                        // Fall through to URL-based detection below.
+                        url.clone()
+                    }
+                    Err(_) => url.clone(),
+                }
+            } else {
+                url.clone()
+            };
+
+            let at_settings = real_url.contains(SETTINGS_PATH)
+                && real_url.starts_with("https://ollama.com");
+            let ollama_authorized = real_url.starts_with("https://ollama.com")
+                && !real_url.contains("/signin")
+                && !real_url.contains("/auth")
+                && !real_url.is_empty()
+                && real_url != "about:blank";
+
+            // Success requires the browser to have returned to ollama.com
+            // after WorkOS auth. A cookie-count increase on signin.ollama.com
+            // is only a pre-auth flow cookie and must not be accepted.
+            let cookie_count_increased = ollama_cookie_count > initial_cookie_count.unwrap_or(0);
+            let auth_cookie_present = cookies.iter().any(|c| {
+                c.name == "__Secure-session" || c.name == "access-token"
+            });
+            let at_landing = (at_settings || ollama_authorized)
+                && ollama_cookie_count >= 2;
+
+            // Log periodically or on interesting changes
+            if real_url != "about:blank" || cookie_count_increased || at_landing {
+                println!(
+                    "ollama-login-helper: url='{}' cookies={} initial={} increased={} auth_cookie={} at_landing={}",
+                    real_url,
+                    ollama_cookie_count,
+                    initial_cookie_count.unwrap_or(0),
+                    cookie_count_increased,
+                    auth_cookie_present,
+                    at_landing
+                );
+            }
+
+            // A persisted authenticated WebView2 profile can legitimately
+            // start at about:blank. The auth cookie is stronger evidence than
+            // the URL in that case; still require the cookie to be for
+            // Ollama's actual session, never merely a signin flow cookie.
+            if !sent && (at_landing || auth_cookie_present) {
+                sent = true;
+                println!(
+                    "ollama-login-helper: SUCCESS — url={} cookies={}",
+                    real_url, ollama_cookie_count
+                );
+                match write_cookie_file(&cookies) {
+                    Ok(()) => {
+                        write_login_done_marker();
+                        exit_code = 0;
+                    }
+                    Err(e) => {
+                        eprintln!("ollama-login-helper: cookie write failed: {e}");
+                        exit_code = 3;
+                    }
+                }
+                *control_flow = ControlFlow::Exit;
+                return;
+            }
+
+            if started.elapsed() > MAX_RUNTIME {
+                println!("ollama-login-helper: timed out after 180s");
+                exit_code = 1;
+                *control_flow = ControlFlow::Exit;
+                return;
+            }
+        }
+    });
+
+    exit_code
+}
+
+#[derive(Debug, Clone)]
+struct Cookie {
+    name: String,
+    value: String,
+}
+
+fn read_cookies(webview: &wry::WebView) -> Vec<Cookie> {
+    match webview.cookies() {
+        Ok(cookies) => cookies
+            .into_iter()
+            .filter(|c| {
+                let name = c.name();
+                let value = c.value();
+                let domain = c.domain().unwrap_or_default();
+                domain.ends_with("ollama.com") && !name.is_empty() && !value.is_empty()
+            })
+            .map(|c| Cookie {
+                name: c.name().to_string(),
+                value: c.value().to_string(),
+            })
+            .collect(),
+        Err(_) => Vec::new(),
+    }
+}
+
+fn build_cookie_header(cookies: &[Cookie]) -> String {
+    cookies
+        .iter()
+        .map(|c| format!("{}={}", c.name, c.value))
+        .collect::<Vec<_>>()
+        .join("; ")
+}
+
+fn write_cookie_file(cookies: &[Cookie]) -> std::io::Result<()> {
+    let path = cookie_file_path()?;
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let header = build_cookie_header(cookies);
+    std::fs::write(&path, header.as_bytes())?;
+    println!(
+        "ollama-login-helper: wrote {} bytes to {}",
+        header.len(),
+        path.display()
+    );
+    Ok(())
+}
+
+fn write_login_done_marker() {
+    if let Ok(path) = cookie_file_path().map(|p| p.with_file_name(LOGIN_DONE_MARKER)) {
+        let _ = std::fs::write(&path, b"1");
+    }
+}
+
+fn cookie_file_path() -> std::io::Result<PathBuf> {
+    let base = std::env::var_os("LOCALAPPDATA")
+        .ok_or_else(|| std::io::Error::new(std::io::ErrorKind::NotFound, "LOCALAPPDATA not set"))?;
+    Ok(PathBuf::from(base)
+        .join("ClaudeCodeUsageMonitor")
+        .join(COOKIE_FILE))
+}

--- a/src/poller.rs
+++ b/src/poller.rs
@@ -369,7 +369,7 @@ fn read_ollama_session_cookie() -> Option<String> {
 }
 
 // Ollama Cloud usage scraper — adapted from bubbabright/usage-daemon (HANDOFF-14
-// from the upstream GNONE-shell + daemon suite). Their parser was the cleanest
+// from the upstream GNOME-shell + daemon suite). Their parser was the cleanest
 // of the half-dozen reference implementations reviewed; we mirror its regexes
 // because they match the actual aria-labelled structure ollama.com emits:
 //

--- a/src/poller.rs
+++ b/src/poller.rs
@@ -175,19 +175,16 @@ pub fn poll(
     show_claude_code: bool,
     show_codex: bool,
     show_antigravity: bool,
-    show_minimax: bool,
     show_ollama: bool,
 ) -> Result<AppUsageData, PollError> {
     poll_with(
         show_claude_code,
         show_codex,
         show_antigravity,
-        show_minimax,
         show_ollama,
         poll_claude_code,
         poll_codex,
         poll_antigravity,
-        poll_minimax,
         poll_ollama,
     )
 }
@@ -196,12 +193,10 @@ fn poll_with(
     show_claude_code: bool,
     show_codex: bool,
     show_antigravity: bool,
-    show_minimax: bool,
     show_ollama: bool,
     mut poll_claude_code: impl FnMut() -> Result<UsageData, PollError>,
     mut poll_codex: impl FnMut() -> Result<UsageData, PollError>,
     mut poll_antigravity: impl FnMut() -> Result<UsageData, PollError>,
-    mut poll_minimax: impl FnMut() -> Result<UsageData, PollError>,
     mut poll_ollama: impl FnMut() -> Result<UsageData, PollError>,
 ) -> Result<AppUsageData, PollError> {
     let mut data = AppUsageData::default();
@@ -209,7 +204,6 @@ fn poll_with(
     let active_provider_count = show_claude_code as u8
         + show_codex as u8
         + show_antigravity as u8
-        + show_minimax as u8
         + show_ollama as u8;
 
     if show_claude_code {
@@ -248,18 +242,6 @@ fn poll_with(
         }
     }
 
-    if show_minimax {
-        match poll_minimax() {
-            Ok(minimax) => data.minimax = Some(minimax),
-            Err(error) => {
-                if active_provider_count > 1 {
-                    diagnose::log(format!("MiniMax usage poll failed: {error:?}"));
-                }
-                first_error.get_or_insert(error);
-            }
-        }
-    }
-
     if show_ollama {
         match poll_ollama() {
             Ok(ollama) => data.ollama = Some(ollama),
@@ -273,16 +255,15 @@ fn poll_with(
     }
 
     if data.claude_code.is_none()
-        && data.codex.is_none()
-        && data.antigravity.is_none()
-        && data.minimax.is_none()
-        && data.ollama.is_none()
-    {
-        Err(first_error.unwrap_or(PollError::RequestFailed))
-    } else {
-        Ok(data)
+            && data.codex.is_none()
+            && data.antigravity.is_none()
+            && data.ollama.is_none()
+        {
+            Err(first_error.unwrap_or(PollError::RequestFailed))
+        } else {
+            Ok(data)
+        }
     }
-}
 
 fn poll_claude_code() -> Result<UsageData, PollError> {
     let creds = match read_first_credentials() {
@@ -330,18 +311,7 @@ fn poll_antigravity() -> Result<UsageData, PollError> {
     fetch_antigravity_usage(&creds.access_token)
 }
 
-fn poll_minimax() -> Result<UsageData, PollError> {
-    // Try to read MiniMax API token from ~/.minimax/credentials or env
-    let token = read_minimax_token();
-
-    match token {
-        Some(t) if !t.is_empty() => fetch_minimax_usage(&t),
-        _ => {
-            diagnose::log("MiniMax usage poll failed: no MiniMax credentials found");
-            Err(PollError::NoCredentials)
-        }
-    }
-}
+const OLLAMA_SETTINGS_URL: &str = "https://ollama.com/settings";
 
 fn poll_ollama() -> Result<UsageData, PollError> {
     // Ollama's real quota values are rendered on the authenticated settings
@@ -357,54 +327,6 @@ fn poll_ollama() -> Result<UsageData, PollError> {
             Err(PollError::NoCredentials)
         }
     }
-}
-
-/// Read the MiniMax credential used by Hermes itself, with compatibility
-/// fallbacks for standalone MiniMax CLI/API-key installs.
-fn read_minimax_token() -> Option<String> {
-    if let Ok(key) = std::env::var("MINIMAX_API_KEY") {
-        if !key.is_empty() {
-            return Some(key);
-        }
-    }
-
-    let home = dirs::home_dir()?;
-
-    // Hermes stores the active OAuth credential here. Prefer this because it
-    // is the same token used by the configured minimax-oauth backend.
-    let auth_path = home.join(".hermes").join("auth.json");
-    if let Ok(content) = std::fs::read_to_string(&auth_path) {
-        if let Ok(json) = serde_json::from_str::<serde_json::Value>(&content) {
-            let provider_token = json
-                .get("providers")
-                .and_then(|v| v.get("minimax-oauth"))
-                .and_then(|v| v.get("access_token"))
-                .and_then(|v| v.as_str());
-            if let Some(token) = provider_token.filter(|s| !s.is_empty()) {
-                return Some(token.to_string());
-            }
-
-            let pool_token = json
-                .get("credential_pool")
-                .and_then(|v| v.get("minimax-oauth"))
-                .and_then(|v| v.as_array())
-                .and_then(|v| v.iter().find(|entry| entry.get("access_token").is_some()))
-                .and_then(|v| v.get("access_token"))
-                .and_then(|v| v.as_str());
-            if let Some(token) = pool_token.filter(|s| !s.is_empty()) {
-                return Some(token.to_string());
-            }
-        }
-    }
-
-    // Compatibility fallback for a standalone MiniMax CLI/API-key install.
-    let cred_path = home.join(".minimax").join("credentials.json");
-    let content = std::fs::read_to_string(&cred_path).ok()?;
-    let json: serde_json::Value = serde_json::from_str(&content).ok()?;
-    json.get("api_key")
-        .and_then(|v| v.as_str())
-        .filter(|s| !s.is_empty())
-        .map(|s| s.to_string())
 }
 
 /// Read the authenticated Ollama Cloud session cookie.
@@ -445,87 +367,6 @@ fn read_ollama_session_cookie() -> Option<String> {
         None
     }
 }
-
-const MINIMAX_TOKEN_PLAN_URL: &str = "https://www.minimax.io/v1/token_plan/remains";
-
-#[derive(Deserialize)]
-struct MiniMaxTokenPlanResponse {
-    model_remains: Vec<MiniMaxModelRemain>,
-}
-
-#[derive(Deserialize)]
-struct MiniMaxModelRemain {
-    model_name: Option<String>,
-    end_time: Option<u64>,
-    weekly_end_time: Option<u64>,
-    current_interval_remaining_percent: Option<f64>,
-    current_weekly_remaining_percent: Option<f64>,
-}
-
-fn minimax_reset_time(ms: Option<u64>) -> Option<SystemTime> {
-    ms.map(|value| UNIX_EPOCH + Duration::from_millis(value))
-}
-
-fn fetch_minimax_usage(token: &str) -> Result<UsageData, PollError> {
-    let agent = build_agent()?;
-
-    let resp = match agent
-        .get(MINIMAX_TOKEN_PLAN_URL)
-        .set("Authorization", &format!("Bearer {token}"))
-        .call()
-    {
-        Ok(resp) => resp,
-        Err(ureq::Error::Status(code, _)) if code == 401 || code == 403 => {
-            diagnose::log(format!(
-                "MiniMax token plan endpoint returned auth error status {code}"
-            ));
-            return Err(PollError::AuthRequired);
-        }
-        Err(error) => {
-            diagnose::log_error("MiniMax token plan request failed", error);
-            return Err(PollError::RequestFailed);
-        }
-    };
-
-    let response: MiniMaxTokenPlanResponse = match resp.into_json() {
-        Ok(response) => response,
-        Err(error) => {
-            diagnose::log_error("unable to parse MiniMax token plan response", error);
-            return Err(PollError::RequestFailed);
-        }
-    };
-
-    // The API returns one bucket per model. The general bucket is the
-    // subscription-wide coding quota; fall back to the first bucket if the
-    // account does not expose a general bucket.
-    let bucket = response
-        .model_remains
-        .iter()
-        .find(|entry| entry.model_name.as_deref() == Some("general"))
-        .or_else(|| response.model_remains.first())
-        .ok_or_else(|| {
-            diagnose::log("MiniMax token plan response contained no model buckets");
-            PollError::RequestFailed
-        })?;
-
-    let mut data = UsageData::default();
-    data.session.percentage = 100.0
-        - bucket
-            .current_interval_remaining_percent
-            .unwrap_or(0.0)
-            .clamp(0.0, 100.0);
-    data.session.resets_at = minimax_reset_time(bucket.end_time);
-    data.weekly.percentage = 100.0
-        - bucket
-            .current_weekly_remaining_percent
-            .unwrap_or(0.0)
-            .clamp(0.0, 100.0);
-    data.weekly.resets_at = minimax_reset_time(bucket.weekly_end_time);
-
-    Ok(data)
-}
-
-const OLLAMA_SETTINGS_URL: &str = "https://ollama.com/settings";
 
 // Ollama Cloud usage scraper — adapted from bubbabright/usage-daemon (HANDOFF-14
 // from the upstream GNONE-shell + daemon suite). Their parser was the cleanest
@@ -2100,7 +1941,6 @@ pub fn app_is_past_reset(data: &AppUsageData) -> bool {
     data.claude_code.as_ref().is_some_and(is_past_reset)
         || data.codex.as_ref().is_some_and(is_past_reset)
         || data.antigravity.as_ref().is_some_and(is_past_reset)
-        || data.minimax.as_ref().is_some_and(is_past_reset)
         || data.ollama.as_ref().is_some_and(is_past_reset)
 }
 
@@ -2119,83 +1959,75 @@ mod tests {
     }
 
     #[test]
-    fn claude_failure_does_not_block_codex_when_both_are_enabled() {
-        let data = poll_with(
-            true,
-            true,
-            false,
-            false,
-            false,
-            || Err(PollError::AuthRequired),
-            || Ok(usage_with_session_percent(42.0)),
-            || unreachable!("antigravity is disabled"),
-            || unreachable!("minimax is disabled"),
-            || unreachable!("ollama is disabled"),
-        )
-        .expect("codex data should keep the poll successful");
+        fn claude_failure_does_not_block_codex_when_both_are_enabled() {
+            let data = poll_with(
+                true,
+                true,
+                false,
+                false,
+                || Err(PollError::AuthRequired),
+                || Ok(usage_with_session_percent(42.0)),
+                || unreachable!("antigravity is disabled"),
+                || unreachable!("ollama is disabled"),
+            )
+            .expect("codex data should keep the poll successful");
 
-        assert!(data.claude_code.is_none());
-        assert_eq!(data.codex.unwrap().session.percentage, 42.0);
-    }
+            assert!(data.claude_code.is_none());
+            assert_eq!(data.codex.unwrap().session.percentage, 42.0);
+        }
 
-    #[test]
-    fn codex_failure_does_not_block_claude_when_both_are_enabled() {
-        let data = poll_with(
-            true,
-            true,
-            false,
-            false,
-            false,
-            || Ok(usage_with_session_percent(64.0)),
-            || Err(PollError::RequestFailed),
-            || unreachable!("antigravity is disabled"),
-            || unreachable!("minimax is disabled"),
-            || unreachable!("ollama is disabled"),
-        )
-        .expect("claude data should keep the poll successful");
+        #[test]
+        fn codex_failure_does_not_block_claude_when_both_are_enabled() {
+            let data = poll_with(
+                true,
+                true,
+                false,
+                false,
+                || Ok(usage_with_session_percent(64.0)),
+                || Err(PollError::RequestFailed),
+                || unreachable!("antigravity is disabled"),
+                || unreachable!("ollama is disabled"),
+            )
+            .expect("claude data should keep the poll successful");
 
-        assert_eq!(data.claude_code.unwrap().session.percentage, 64.0);
-        assert!(data.codex.is_none());
-    }
+            assert_eq!(data.claude_code.unwrap().session.percentage, 64.0);
+            assert!(data.codex.is_none());
+        }
 
-    #[test]
-    fn returns_first_error_when_no_enabled_provider_succeeds() {
-        let error = poll_with(
-            true,
-            true,
-            true,
-            false,
-            false,
-            || Err(PollError::AuthRequired),
-            || Err(PollError::RequestFailed),
-            || Err(PollError::NoCredentials),
-            || unreachable!("minimax is disabled"),
-            || unreachable!("ollama is disabled"),
-        )
-        .expect_err("all-provider failure should return an error");
+        #[test]
+        fn returns_first_error_when_no_enabled_provider_succeeds() {
+            let error = poll_with(
+                true,
+                true,
+                true,
+                false,
+                || Err(PollError::AuthRequired),
+                || Err(PollError::RequestFailed),
+                || Err(PollError::NoCredentials),
+                || unreachable!("ollama is disabled"),
+            )
+            .expect_err("all-provider failure should return an error");
 
-        assert_eq!(error, PollError::AuthRequired);
-    }
+            assert_eq!(error, PollError::AuthRequired);
+        }
 
-    #[test]
-    fn antigravity_failure_does_not_block_codex_when_both_are_enabled() {
-        let data = poll_with(
-            false,
-            true,
-            true,
-            false,
-            false,
-            || unreachable!("claude code is disabled"),
-            || Ok(usage_with_session_percent(42.0)),
-            || Err(PollError::NoCredentials),
-            || unreachable!("minimax is disabled"),
-            || unreachable!("ollama is disabled"),
-        )
-        .expect("codex data should keep the poll successful");
+        #[test]
+        fn antigravity_failure_does_not_block_codex_when_both_are_enabled() {
+            let data = poll_with(
+                false,
+                true,
+                true,
+                false,
+                || unreachable!("claude code is disabled"),
+                || Ok(usage_with_session_percent(42.0)),
+                || Err(PollError::NoCredentials),
+                || unreachable!("ollama is disabled"),
+            )
+            .expect("codex data should keep the poll successful");
 
-        assert!(data.antigravity.is_none());
-        assert_eq!(data.codex.unwrap().session.percentage, 42.0);
-    }
+            assert!(data.antigravity.is_none());
+            assert_eq!(data.codex.unwrap().session.percentage, 42.0);
+        }
 
     #[test]
     fn antigravity_summary_prefers_gemini_group() {

--- a/src/poller.rs
+++ b/src/poller.rs
@@ -175,14 +175,20 @@ pub fn poll(
     show_claude_code: bool,
     show_codex: bool,
     show_antigravity: bool,
+    show_minimax: bool,
+    show_ollama: bool,
 ) -> Result<AppUsageData, PollError> {
     poll_with(
         show_claude_code,
         show_codex,
         show_antigravity,
+        show_minimax,
+        show_ollama,
         poll_claude_code,
         poll_codex,
         poll_antigravity,
+        poll_minimax,
+        poll_ollama,
     )
 }
 
@@ -190,13 +196,21 @@ fn poll_with(
     show_claude_code: bool,
     show_codex: bool,
     show_antigravity: bool,
+    show_minimax: bool,
+    show_ollama: bool,
     mut poll_claude_code: impl FnMut() -> Result<UsageData, PollError>,
     mut poll_codex: impl FnMut() -> Result<UsageData, PollError>,
     mut poll_antigravity: impl FnMut() -> Result<UsageData, PollError>,
+    mut poll_minimax: impl FnMut() -> Result<UsageData, PollError>,
+    mut poll_ollama: impl FnMut() -> Result<UsageData, PollError>,
 ) -> Result<AppUsageData, PollError> {
     let mut data = AppUsageData::default();
     let mut first_error = None;
-    let active_provider_count = show_claude_code as u8 + show_codex as u8 + show_antigravity as u8;
+    let active_provider_count = show_claude_code as u8
+        + show_codex as u8
+        + show_antigravity as u8
+        + show_minimax as u8
+        + show_ollama as u8;
 
     if show_claude_code {
         match poll_claude_code() {
@@ -234,7 +248,36 @@ fn poll_with(
         }
     }
 
-    if data.claude_code.is_none() && data.codex.is_none() && data.antigravity.is_none() {
+    if show_minimax {
+        match poll_minimax() {
+            Ok(minimax) => data.minimax = Some(minimax),
+            Err(error) => {
+                if active_provider_count > 1 {
+                    diagnose::log(format!("MiniMax usage poll failed: {error:?}"));
+                }
+                first_error.get_or_insert(error);
+            }
+        }
+    }
+
+    if show_ollama {
+        match poll_ollama() {
+            Ok(ollama) => data.ollama = Some(ollama),
+            Err(error) => {
+                if active_provider_count > 1 {
+                    diagnose::log(format!("Ollama usage poll failed: {error:?}"));
+                }
+                first_error.get_or_insert(error);
+            }
+        }
+    }
+
+    if data.claude_code.is_none()
+        && data.codex.is_none()
+        && data.antigravity.is_none()
+        && data.minimax.is_none()
+        && data.ollama.is_none()
+    {
         Err(first_error.unwrap_or(PollError::RequestFailed))
     } else {
         Ok(data)
@@ -285,6 +328,362 @@ fn poll_antigravity() -> Result<UsageData, PollError> {
     };
 
     fetch_antigravity_usage(&creds.access_token)
+}
+
+fn poll_minimax() -> Result<UsageData, PollError> {
+    // Try to read MiniMax API token from ~/.minimax/credentials or env
+    let token = read_minimax_token();
+
+    match token {
+        Some(t) if !t.is_empty() => fetch_minimax_usage(&t),
+        _ => {
+            diagnose::log("MiniMax usage poll failed: no MiniMax credentials found");
+            Err(PollError::NoCredentials)
+        }
+    }
+}
+
+fn poll_ollama() -> Result<UsageData, PollError> {
+    // Ollama's real quota values are rendered on the authenticated settings
+    // page. The API key can identify the plan, but cannot return consumption.
+    let cookie = read_ollama_session_cookie();
+
+    match cookie {
+        Some(cookie) if !cookie.is_empty() => fetch_ollama_usage(&cookie),
+        _ => {
+            diagnose::log(
+                "Ollama usage poll failed: no Ollama Cloud session cookie found; refusing to display plan-tier guesses",
+            );
+            Err(PollError::NoCredentials)
+        }
+    }
+}
+
+/// Read the MiniMax credential used by Hermes itself, with compatibility
+/// fallbacks for standalone MiniMax CLI/API-key installs.
+fn read_minimax_token() -> Option<String> {
+    if let Ok(key) = std::env::var("MINIMAX_API_KEY") {
+        if !key.is_empty() {
+            return Some(key);
+        }
+    }
+
+    let home = dirs::home_dir()?;
+
+    // Hermes stores the active OAuth credential here. Prefer this because it
+    // is the same token used by the configured minimax-oauth backend.
+    let auth_path = home.join(".hermes").join("auth.json");
+    if let Ok(content) = std::fs::read_to_string(&auth_path) {
+        if let Ok(json) = serde_json::from_str::<serde_json::Value>(&content) {
+            let provider_token = json
+                .get("providers")
+                .and_then(|v| v.get("minimax-oauth"))
+                .and_then(|v| v.get("access_token"))
+                .and_then(|v| v.as_str());
+            if let Some(token) = provider_token.filter(|s| !s.is_empty()) {
+                return Some(token.to_string());
+            }
+
+            let pool_token = json
+                .get("credential_pool")
+                .and_then(|v| v.get("minimax-oauth"))
+                .and_then(|v| v.as_array())
+                .and_then(|v| v.iter().find(|entry| entry.get("access_token").is_some()))
+                .and_then(|v| v.get("access_token"))
+                .and_then(|v| v.as_str());
+            if let Some(token) = pool_token.filter(|s| !s.is_empty()) {
+                return Some(token.to_string());
+            }
+        }
+    }
+
+    // Compatibility fallback for a standalone MiniMax CLI/API-key install.
+    let cred_path = home.join(".minimax").join("credentials.json");
+    let content = std::fs::read_to_string(&cred_path).ok()?;
+    let json: serde_json::Value = serde_json::from_str(&content).ok()?;
+    json.get("api_key")
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_string())
+}
+
+/// Read the authenticated Ollama Cloud session cookie.
+///
+/// Priority:
+/// 1. OLLAMA_CLOUD_SESSION environment variable
+/// 2. Local app file (so Explorer/launched-at-login builds can use it)
+/// 3. ~/.claude/settings.json env.OLLAMA_CLOUD_SESSION
+fn read_ollama_session_cookie() -> Option<String> {
+    if let Ok(cookie) = std::env::var("OLLAMA_CLOUD_SESSION") {
+        if cookie.contains("aid=") && cookie.contains("__Secure-session=") {
+            return Some(cookie);
+        }
+    }
+
+    if let Some(local_data) = dirs::data_local_dir() {
+        let cookie_path = local_data
+            .join("ClaudeCodeUsageMonitor")
+            .join("ollama_session_cookie.txt");
+        if let Ok(cookie) = std::fs::read_to_string(cookie_path) {
+            let cookie = cookie.trim().to_string();
+            if cookie.contains("aid=") && cookie.contains("__Secure-session=") {
+                return Some(cookie);
+            }
+        }
+    }
+
+    let settings_path = dirs::home_dir()?.join(".claude").join("settings.json");
+    let content = std::fs::read_to_string(settings_path).ok()?;
+    let json: serde_json::Value = serde_json::from_str(&content).ok()?;
+    let cookie = json
+        .get("env")
+        .and_then(|env| env.get("OLLAMA_CLOUD_SESSION"))
+        .and_then(|value| value.as_str())?;
+    if cookie.contains("aid=") && cookie.contains("__Secure-session=") {
+        Some(cookie.to_string())
+    } else {
+        None
+    }
+}
+
+const MINIMAX_TOKEN_PLAN_URL: &str = "https://www.minimax.io/v1/token_plan/remains";
+
+#[derive(Deserialize)]
+struct MiniMaxTokenPlanResponse {
+    model_remains: Vec<MiniMaxModelRemain>,
+}
+
+#[derive(Deserialize)]
+struct MiniMaxModelRemain {
+    model_name: Option<String>,
+    end_time: Option<u64>,
+    weekly_end_time: Option<u64>,
+    current_interval_remaining_percent: Option<f64>,
+    current_weekly_remaining_percent: Option<f64>,
+}
+
+fn minimax_reset_time(ms: Option<u64>) -> Option<SystemTime> {
+    ms.map(|value| UNIX_EPOCH + Duration::from_millis(value))
+}
+
+fn fetch_minimax_usage(token: &str) -> Result<UsageData, PollError> {
+    let agent = build_agent()?;
+
+    let resp = match agent
+        .get(MINIMAX_TOKEN_PLAN_URL)
+        .set("Authorization", &format!("Bearer {token}"))
+        .call()
+    {
+        Ok(resp) => resp,
+        Err(ureq::Error::Status(code, _)) if code == 401 || code == 403 => {
+            diagnose::log(format!(
+                "MiniMax token plan endpoint returned auth error status {code}"
+            ));
+            return Err(PollError::AuthRequired);
+        }
+        Err(error) => {
+            diagnose::log_error("MiniMax token plan request failed", error);
+            return Err(PollError::RequestFailed);
+        }
+    };
+
+    let response: MiniMaxTokenPlanResponse = match resp.into_json() {
+        Ok(response) => response,
+        Err(error) => {
+            diagnose::log_error("unable to parse MiniMax token plan response", error);
+            return Err(PollError::RequestFailed);
+        }
+    };
+
+    // The API returns one bucket per model. The general bucket is the
+    // subscription-wide coding quota; fall back to the first bucket if the
+    // account does not expose a general bucket.
+    let bucket = response
+        .model_remains
+        .iter()
+        .find(|entry| entry.model_name.as_deref() == Some("general"))
+        .or_else(|| response.model_remains.first())
+        .ok_or_else(|| {
+            diagnose::log("MiniMax token plan response contained no model buckets");
+            PollError::RequestFailed
+        })?;
+
+    let mut data = UsageData::default();
+    data.session.percentage = 100.0
+        - bucket
+            .current_interval_remaining_percent
+            .unwrap_or(0.0)
+            .clamp(0.0, 100.0);
+    data.session.resets_at = minimax_reset_time(bucket.end_time);
+    data.weekly.percentage = 100.0
+        - bucket
+            .current_weekly_remaining_percent
+            .unwrap_or(0.0)
+            .clamp(0.0, 100.0);
+    data.weekly.resets_at = minimax_reset_time(bucket.weekly_end_time);
+
+    Ok(data)
+}
+
+const OLLAMA_SETTINGS_URL: &str = "https://ollama.com/settings";
+
+// Ollama Cloud usage scraper — adapted from bubbabright/usage-daemon (HANDOFF-14
+// from the upstream GNONE-shell + daemon suite). Their parser was the cleanest
+// of the half-dozen reference implementations reviewed; we mirror its regexes
+// because they match the actual aria-labelled structure ollama.com emits:
+//
+//   <span aria-label="Session usage 100% used" ...>
+//   <span aria-label="Weekly usage 26.5% used" ...>
+//
+// followed by two <span data-time="...">Resets in N hours</span> elements for
+// the next 5h / weekly reset timestamps.
+
+#[derive(Debug, PartialEq)]
+#[allow(dead_code)]
+enum OllamaParseError {
+    /// HTML body did not contain the "Cloud usage" header — user is logged out
+    /// or ollama changed the page layout.
+    AuthExpired,
+    /// Could not parse one or both percentages out of an otherwise-valid page.
+    ParseFailed,
+}
+
+fn fetch_ollama_usage(cookie: &str) -> Result<UsageData, PollError> {
+    let agent = build_ollama_agent()?;
+
+    let resp = match agent
+        .get(OLLAMA_SETTINGS_URL)
+        .set("Cookie", cookie)
+        .set(
+            "User-Agent",
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 \
+             (KHTML, like Gecko) Chrome/127.0.0.0 Safari/537.36",
+        )
+        .set("Accept", "text/html,application/xhtml+xml")
+        .call()
+    {
+        Ok(resp) => resp,
+        Err(ureq::Error::Status(code, _)) if code == 401 || code == 403 => {
+            diagnose::log(format!(
+                "Ollama settings page returned auth error status {code}"
+            ));
+            return Err(PollError::AuthRequired);
+        }
+        Err(ureq::Error::Status(code, _)) if (300..400).contains(&code) => {
+            // usage-daemon's ollama.js does `redirect: 'manual'` — a 3xx from
+            // ollama.com/settings is the auth-expired signal, not a real
+            // navigation we should silently follow.
+            diagnose::log(format!(
+                "Ollama settings page redirected with status {code} (likely to /signin)"
+            ));
+            return Err(PollError::AuthRequired);
+        }
+        Err(ureq::Error::Status(429, response)) => {
+            let retry_after = response
+                .header("Retry-After")
+                .and_then(|v| v.parse::<u64>().ok());
+            diagnose::log(format!(
+                "Ollama settings page rate-limited (Retry-After={retry_after:?})"
+            ));
+            return Err(PollError::RequestFailed);
+        }
+        Err(error) => {
+            diagnose::log_error("Ollama settings page request failed", error);
+            return Err(PollError::RequestFailed);
+        }
+    };
+
+    let html: String = match resp.into_string() {
+        Ok(html) => html,
+        Err(error) => {
+            diagnose::log_error("unable to read Ollama settings page", error);
+            return Err(PollError::RequestFailed);
+        }
+    };
+
+    parse_ollama_usage(&html).map_err(|err| match err {
+        OllamaParseError::AuthExpired => {
+            diagnose::log("Ollama settings page did not contain Cloud usage header (auth expired)");
+            PollError::AuthRequired
+        }
+        OllamaParseError::ParseFailed => {
+            diagnose::log("Ollama settings page missing Session/Weekly usage percentages");
+            PollError::RequestFailed
+        }
+    })
+}
+
+/// Ollama-specific ureq agent. Distinct from `build_agent` because Ollama needs
+/// `redirects(0)` (so a 303 → /signin surfaces as a Status error we can
+/// recognise, instead of being followed silently), and a browser-flavoured
+/// User-Agent.
+fn build_ollama_agent() -> Result<ureq::Agent, PollError> {
+    let tls = native_tls::TlsConnector::new().map_err(|_| PollError::RequestFailed)?;
+    Ok(ureq::AgentBuilder::new()
+        .timeout(Duration::from_secs(30))
+        .redirects(0)
+        .tls_connector(std::sync::Arc::new(tls))
+        .build())
+}
+
+/// Pure function of the HTML body — used by the tests in
+/// `mod ollama_usage_tests` below to verify the parser against fixtures
+/// without doing real network. Mirrors `parse()` in usage-daemon's
+/// `providers/ollama.js`.
+fn parse_ollama_usage(html: &str) -> Result<UsageData, OllamaParseError> {
+    // Auth gate — the "Cloud usage" heading only appears on a logged-in
+    // settings page. A redirect to /signin omits this entirely.
+    if !html.contains("Cloud usage") {
+        return Err(OllamaParseError::AuthExpired);
+    }
+
+    let session_percentage = parse_ollama_aria_percentage(html, "Session usage")
+        .ok_or(OllamaParseError::ParseFailed)?;
+    let weekly_percentage = parse_ollama_aria_percentage(html, "Weekly usage")
+        .ok_or(OllamaParseError::ParseFailed)?;
+
+    let resets = parse_ollama_reset_times(html);
+    let mut data = UsageData::default();
+    data.session.percentage = session_percentage.clamp(0.0, 100.0);
+    data.weekly.percentage = weekly_percentage.clamp(0.0, 100.0);
+    data.session.resets_at = resets.first().copied().flatten();
+    data.weekly.resets_at = resets.get(1).copied().flatten();
+
+    Ok(data)
+}
+
+/// Match `aria-label="Session usage 26.5% used"` (decimal allowed).
+fn parse_ollama_aria_percentage(html: &str, label: &str) -> Option<f64> {
+    let needle = format!("aria-label=\"{label} ");
+    let start = html.find(&needle)? + needle.len();
+    let after = &html[start..];
+    let end = after.find('%')?;
+    let number = after[..end].trim();
+    number.parse::<f64>().ok()
+}
+
+fn parse_ollama_reset_times(html: &str) -> Vec<Option<SystemTime>> {
+    let mut results = Vec::new();
+    let mut offset = 0;
+
+    while let Some(relative) = html[offset..].find("data-time=\"") {
+        let value_start = offset + relative + "data-time=\"".len();
+        let Some(value_end_relative) = html[value_start..].find('"') else {
+            break;
+        };
+        let value_end = value_start + value_end_relative;
+        let after_end = (value_end + 300).min(html.len());
+        let after = &html[value_end..after_end];
+        if after.contains("Resets in") {
+            results.push(parse_iso8601(Some(&html[value_start..value_end])));
+            if results.len() >= 2 {
+                break;
+            }
+        }
+        offset = value_end + 1;
+    }
+
+    results
 }
 
 fn refresh_or_fallback(mut creds: Credentials) -> Result<Credentials, PollError> {
@@ -1521,6 +1920,109 @@ fn is_leap(y: u64) -> bool {
     (y % 4 == 0 && y % 100 != 0) || y % 400 == 0
 }
 
+#[cfg(test)]
+mod ollama_usage_tests {
+    use super::{parse_ollama_aria_percentage, parse_ollama_reset_times, parse_ollama_usage};
+    use crate::models::UsageData;
+
+    /// Minimal-but-faithful settings-page fixture. The "Cloud usage" heading +
+    /// aria-label pattern is what bubbabright/usage-daemon's parser keys on;
+    /// keeping the same markup ensures we're matching the same page.
+    const FIXTURE_LOGGED_IN: &str = r#"
+        <main>
+          <h2>Cloud usage <span class="capitalize">pro</span></h2>
+          <p>Cloud models and capabilities such as web search contribute to session and weekly limits.</p>
+          <section>
+            <span aria-label="Session usage 100% used">100% used</span>
+            <span data-time="2026-07-23T16:00:00Z">Resets in 2 hours</span>
+          </section>
+          <section>
+            <span aria-label="Weekly usage 26.5% used">26.5% used</span>
+            <span data-time="2026-07-26T14:00:00Z">Resets in 3 days</span>
+          </section>
+        </main>
+    "#;
+
+    const FIXTURE_LOGGED_OUT: &str = r#"
+        <html><head><title>Sign in</title></head>
+        <body><h2>Sign in to Ollama</h2></body></html>
+    "#;
+
+    const FIXTURE_GENUINE_ZERO: &str = r#"
+        <main>
+          <h2>Cloud usage <span class="capitalize">free</span></h2>
+          <section>
+            <span aria-label="Session usage 0% used">0% used</span>
+            <span data-time="2026-07-23T20:00:00Z">Resets in 5 hours</span>
+          </section>
+          <section>
+            <span aria-label="Weekly usage 0% used">0% used</span>
+            <span data-time="2026-07-30T00:00:00Z">Resets in 6 days</span>
+          </section>
+        </main>
+    "#;
+
+    #[test]
+    fn parses_actual_ollama_usage_labels() {
+        let data = parse_ollama_usage(FIXTURE_LOGGED_IN).expect("logged-in fixture should parse");
+        assert_eq!(data.session.percentage, 100.0);
+        assert_eq!(data.weekly.percentage, 26.5);
+        assert!(data.session.resets_at.is_some(), "session reset must parse");
+        assert!(data.weekly.resets_at.is_some(), "weekly reset must parse");
+    }
+
+    #[test]
+    fn parses_zero_usage_fixture() {
+        let data = parse_ollama_usage(FIXTURE_GENUINE_ZERO).expect("0% fixture should parse");
+        assert_eq!(data.session.percentage, 0.0);
+        assert_eq!(data.weekly.percentage, 0.0);
+    }
+
+    #[test]
+    fn auth_expired_when_cloud_usage_heading_missing() {
+        let err = parse_ollama_usage(FIXTURE_LOGGED_OUT)
+            .err()
+            .expect("logged-out fixture must fail");
+        assert!(
+            matches!(err, super::OllamaParseError::AuthExpired),
+            "expected AuthExpired, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn parse_failed_when_percent_missing() {
+        // Page has "Cloud usage" but no aria-label percentages — must NOT silently
+        // default to 0; must report ParseFailed so the tray shows `??` rather
+        // than a misleading 0% reading.
+        let html = r#"<main><h2>Cloud usage</h2></main>"#;
+        let err = parse_ollama_usage(html).err().expect("must fail");
+        assert!(matches!(err, super::OllamaParseError::ParseFailed));
+    }
+
+    #[test]
+    fn aria_label_matcher_handles_decimals_and_whitespace() {
+        let html = r#"<span aria-label="Session usage 26.5% used">"#;
+        assert_eq!(parse_ollama_aria_percentage(html, "Session usage"), Some(26.5));
+    }
+
+    #[test]
+    fn reset_times_pair_session_then_weekly() {
+        let times = parse_ollama_reset_times(FIXTURE_LOGGED_IN);
+        assert_eq!(times.len(), 2, "expected session + weekly resets");
+    }
+
+    #[test]
+    fn usage_data_default_helper_does_not_silently_zero() {
+        // Defensive: ensure an empty UsageData really is `??` for the UI, not 0.
+        let d = UsageData::default();
+        assert_eq!(d.session.percentage, 0.0);
+        assert_eq!(d.weekly.percentage, 0.0);
+        assert!(d.session.resets_at.is_none());
+        assert!(d.weekly.resets_at.is_none());
+    }
+}
+
+
 /// Format a usage section as "X% · Yh" style text
 pub fn format_line(section: &UsageSection, strings: Strings) -> String {
     let pct = format!("{:.0}%", section.percentage);
@@ -1598,6 +2100,8 @@ pub fn app_is_past_reset(data: &AppUsageData) -> bool {
     data.claude_code.as_ref().is_some_and(is_past_reset)
         || data.codex.as_ref().is_some_and(is_past_reset)
         || data.antigravity.as_ref().is_some_and(is_past_reset)
+        || data.minimax.as_ref().is_some_and(is_past_reset)
+        || data.ollama.as_ref().is_some_and(is_past_reset)
 }
 
 #[cfg(test)]
@@ -1620,9 +2124,13 @@ mod tests {
             true,
             true,
             false,
+            false,
+            false,
             || Err(PollError::AuthRequired),
             || Ok(usage_with_session_percent(42.0)),
             || unreachable!("antigravity is disabled"),
+            || unreachable!("minimax is disabled"),
+            || unreachable!("ollama is disabled"),
         )
         .expect("codex data should keep the poll successful");
 
@@ -1636,9 +2144,13 @@ mod tests {
             true,
             true,
             false,
+            false,
+            false,
             || Ok(usage_with_session_percent(64.0)),
             || Err(PollError::RequestFailed),
             || unreachable!("antigravity is disabled"),
+            || unreachable!("minimax is disabled"),
+            || unreachable!("ollama is disabled"),
         )
         .expect("claude data should keep the poll successful");
 
@@ -1652,9 +2164,13 @@ mod tests {
             true,
             true,
             true,
+            false,
+            false,
             || Err(PollError::AuthRequired),
             || Err(PollError::RequestFailed),
             || Err(PollError::NoCredentials),
+            || unreachable!("minimax is disabled"),
+            || unreachable!("ollama is disabled"),
         )
         .expect_err("all-provider failure should return an error");
 
@@ -1667,9 +2183,13 @@ mod tests {
             false,
             true,
             true,
+            false,
+            false,
             || unreachable!("claude code is disabled"),
             || Ok(usage_with_session_percent(42.0)),
             || Err(PollError::NoCredentials),
+            || unreachable!("minimax is disabled"),
+            || unreachable!("ollama is disabled"),
         )
         .expect("codex data should keep the poll successful");
 

--- a/src/tray_icon.rs
+++ b/src/tray_icon.rs
@@ -13,6 +13,7 @@ use crate::native_interop::{self, Color, WM_APP_TRAY};
 const CLAUDE_TRAY_ICON_ID: u32 = 1;
 const CODEX_TRAY_ICON_ID: u32 = 2;
 const ANTIGRAVITY_TRAY_ICON_ID: u32 = 3;
+const OLLAMA_TRAY_ICON_ID: u32 = 4;
 
 /// Menu item ID for toggling widget visibility (used by window.rs context menu).
 pub const IDM_TOGGLE_WIDGET: u16 = 70;
@@ -29,6 +30,7 @@ pub enum TrayIconKind {
     Claude,
     Codex,
     Antigravity,
+    Ollama,
 }
 
 pub struct TrayIconData {
@@ -43,6 +45,7 @@ impl TrayIconKind {
             Self::Claude => CLAUDE_TRAY_ICON_ID,
             Self::Codex => CODEX_TRAY_ICON_ID,
             Self::Antigravity => ANTIGRAVITY_TRAY_ICON_ID,
+            Self::Ollama => OLLAMA_TRAY_ICON_ID,
         }
     }
 }
@@ -101,6 +104,14 @@ fn antigravity_fill(percent: f64) -> Color {
     }
 }
 
+fn ollama_fill(percent: f64) -> Color {
+    if percent >= 90.0 {
+        Color::from_hex("#FFFFFF")
+    } else {
+        Color::from_hex("#676BEC")
+    }
+}
+
 /// Create a rounded-rectangle tray icon badge showing the usage percentage.
 /// For Claude, `percent` = None uses the embedded app icon as the loading state.
 /// For Codex and Antigravity, `percent` = None uses a provider placeholder badge.
@@ -115,7 +126,10 @@ pub fn create_icon(kind: TrayIconKind, percent: Option<f64>) -> HICON {
     let size = 64_i32;
     let margin = 0_i32;
     let radius = 2_i32;
-    let outline = if matches!(kind, TrayIconKind::Codex | TrayIconKind::Antigravity) {
+    let outline = if matches!(
+        kind,
+        TrayIconKind::Codex | TrayIconKind::Antigravity | TrayIconKind::Ollama
+    ) {
         3_i32
     } else {
         0_i32
@@ -125,6 +139,7 @@ pub fn create_icon(kind: TrayIconKind, percent: Option<f64>) -> HICON {
         TrayIconKind::Claude => interpolated_fill(percent.unwrap_or(0.0)),
         TrayIconKind::Codex => codex_fill(percent.unwrap_or(0.0)),
         TrayIconKind::Antigravity => antigravity_fill(percent.unwrap_or(0.0)),
+        TrayIconKind::Ollama => ollama_fill(percent.unwrap_or(0.0)),
     };
     let text_col = match kind {
         TrayIconKind::Claude => Color::from_hex("#FFFFFF"),
@@ -132,6 +147,8 @@ pub fn create_icon(kind: TrayIconKind, percent: Option<f64>) -> HICON {
         TrayIconKind::Codex => Color::from_hex("#FFFFFF"),
         TrayIconKind::Antigravity if percent.unwrap_or(0.0) >= 90.0 => Color::from_hex("#1967D2"),
         TrayIconKind::Antigravity => Color::from_hex("#FFFFFF"),
+        TrayIconKind::Ollama if percent.unwrap_or(0.0) >= 90.0 => Color::from_hex("#3D41B0"),
+        TrayIconKind::Ollama => Color::from_hex("#FFFFFF"),
     };
     let outline_col = match kind {
         TrayIconKind::Claude => fill,
@@ -139,6 +156,8 @@ pub fn create_icon(kind: TrayIconKind, percent: Option<f64>) -> HICON {
         TrayIconKind::Codex => Color::from_hex("#FFFFFF"),
         TrayIconKind::Antigravity if percent.unwrap_or(0.0) >= 90.0 => Color::from_hex("#1967D2"),
         TrayIconKind::Antigravity => Color::from_hex("#FFFFFF"),
+        TrayIconKind::Ollama if percent.unwrap_or(0.0) >= 90.0 => Color::from_hex("#3D41B0"),
+        TrayIconKind::Ollama => Color::from_hex("#FFFFFF"),
     };
 
     let display_text = match percent {
@@ -147,6 +166,7 @@ pub fn create_icon(kind: TrayIconKind, percent: Option<f64>) -> HICON {
             TrayIconKind::Claude => String::new(),
             TrayIconKind::Codex => "C".to_string(),
             TrayIconKind::Antigravity => "A".to_string(),
+            TrayIconKind::Ollama => "O".to_string(),
         },
     };
 
@@ -417,6 +437,9 @@ pub fn sync(hwnd: HWND, icons: &[TrayIconData]) {
     let show_antigravity = icons
         .iter()
         .find(|icon| matches!(icon.kind, TrayIconKind::Antigravity));
+    let show_ollama = icons
+        .iter()
+        .find(|icon| matches!(icon.kind, TrayIconKind::Ollama));
 
     if let Some(icon) = show_claude {
         add(hwnd, icon.kind, icon.percent, &icon.tooltip);
@@ -438,12 +461,20 @@ pub fn sync(hwnd: HWND, icons: &[TrayIconData]) {
     } else {
         remove(hwnd, TrayIconKind::Antigravity);
     }
+
+    if let Some(icon) = show_ollama {
+        add(hwnd, icon.kind, icon.percent, &icon.tooltip);
+        update(hwnd, icon.kind, icon.percent, &icon.tooltip);
+    } else {
+        remove(hwnd, TrayIconKind::Ollama);
+    }
 }
 
 pub fn remove_all(hwnd: HWND) {
     remove(hwnd, TrayIconKind::Claude);
     remove(hwnd, TrayIconKind::Codex);
     remove(hwnd, TrayIconKind::Antigravity);
+    remove(hwnd, TrayIconKind::Ollama);
 }
 
 /// Interpret a tray callback message and return the action to take.

--- a/src/window.rs
+++ b/src/window.rs
@@ -67,10 +67,6 @@ struct AppState {
     antigravity_session_text: String,
     antigravity_weekly_percent: f64,
     antigravity_weekly_text: String,
-    minimax_session_percent: f64,
-    minimax_session_text: String,
-    minimax_weekly_percent: f64,
-    minimax_weekly_text: String,
     ollama_session_percent: f64,
     ollama_session_text: String,
     ollama_weekly_percent: f64,
@@ -78,7 +74,6 @@ struct AppState {
     show_claude_code: bool,
     show_codex: bool,
     show_antigravity: bool,
-    show_minimax: bool,
     show_ollama: bool,
 
     data: Option<AppUsageData>,
@@ -142,7 +137,6 @@ const IDM_LANG_SIMPLIFIED_CHINESE: u16 = 51;
 const IDM_MODEL_CLAUDE_CODE: u16 = 60;
 const IDM_MODEL_CODEX: u16 = 61;
 const IDM_MODEL_ANTIGRAVITY: u16 = 62;
-const IDM_MODEL_MINIMAX: u16 = 63;
 const IDM_MODEL_OLLAMA: u16 = 64;
 #[cfg(feature = "ollama-login-webview")]
 const IDM_LOGIN_OLLAMA: u16 = 65;
@@ -331,8 +325,6 @@ struct SettingsFile {
     show_codex: bool,
     #[serde(default = "default_show_antigravity")]
     show_antigravity: bool,
-    #[serde(default = "default_show_minimax")]
-    show_minimax: bool,
     #[serde(default = "default_show_ollama")]
     show_ollama: bool,
 }
@@ -349,7 +341,6 @@ impl Default for SettingsFile {
             show_claude_code: true,
             show_codex: false,
             show_antigravity: false,
-            show_minimax: false,
             show_ollama: false,
         }
     }
@@ -375,10 +366,6 @@ fn default_show_antigravity() -> bool {
     false
 }
 
-fn default_show_minimax() -> bool {
-    false
-}
-
 fn default_show_ollama() -> bool {
     false
 }
@@ -392,7 +379,6 @@ fn load_settings() -> SettingsFile {
     if !settings.show_claude_code
         && !settings.show_codex
         && !settings.show_antigravity
-        && !settings.show_minimax
         && !settings.show_ollama
     {
         settings.show_claude_code = true;
@@ -425,7 +411,6 @@ fn save_state_settings() {
             show_claude_code: s.show_claude_code,
             show_codex: s.show_codex,
             show_antigravity: s.show_antigravity,
-            show_minimax: s.show_minimax,
             show_ollama: s.show_ollama,
         });
     }
@@ -472,18 +457,6 @@ fn tray_icon_data_from_state() -> Vec<tray_icon::TrayIconData> {
                     ),
                 });
             }
-            if s.show_minimax {
-                icons.push(tray_icon::TrayIconData {
-                    kind: tray_icon::TrayIconKind::Antigravity,
-                    percent: Some(s.minimax_session_percent),
-                    tooltip: format!(
-                        "{} 5h: {} | 7d: {}",
-                        s.language.strings().minimax_model,
-                        s.minimax_session_text,
-                        s.minimax_weekly_text
-                    ),
-                });
-            }
             if s.show_ollama {
                 icons.push(tray_icon::TrayIconData {
                     kind: tray_icon::TrayIconKind::Antigravity,
@@ -519,13 +492,6 @@ fn tray_icon_data_from_state() -> Vec<tray_icon::TrayIconData> {
                     kind: tray_icon::TrayIconKind::Antigravity,
                     percent: None,
                     tooltip: s.language.strings().antigravity_window_title.to_string(),
-                });
-            }
-            if s.show_minimax {
-                icons.push(tray_icon::TrayIconData {
-                    kind: tray_icon::TrayIconKind::Antigravity,
-                    percent: None,
-                    tooltip: s.language.strings().minimax_window_title.to_string(),
                 });
             }
             if s.show_ollama {
@@ -745,19 +711,6 @@ fn refresh_usage_texts(state: &mut AppState) {
     } else if state.show_antigravity {
         state.antigravity_session_text = "!".to_string();
         state.antigravity_weekly_text = "!".to_string();
-    }
-
-    if let Some(minimax) = data.minimax.as_ref() {
-        state.minimax_session_text = poller::format_line(&minimax.session, strings);
-        state.minimax_weekly_text =
-            if minimax.weekly.resets_at.is_none() && minimax.weekly.percentage == 0.0 {
-                "--".to_string()
-            } else {
-                poller::format_line(&minimax.weekly, strings)
-            };
-    } else if state.show_minimax {
-        state.minimax_session_text = "!".to_string();
-        state.minimax_weekly_text = "!".to_string();
     }
 
     if let Some(ollama) = data.ollama.as_ref() {
@@ -1183,13 +1136,11 @@ fn active_model_count(
     show_claude_code: bool,
     show_codex: bool,
     show_antigravity: bool,
-    show_minimax: bool,
     show_ollama: bool,
 ) -> i32 {
     (show_claude_code as i32
         + show_codex as i32
         + show_antigravity as i32
-        + show_minimax as i32
         + show_ollama as i32)
         .max(1)
 }
@@ -1222,7 +1173,6 @@ fn total_widget_width_for_state(state: &AppState) -> i32 {
         state.show_claude_code,
         state.show_codex,
         state.show_antigravity,
-        state.show_minimax,
         state.show_ollama,
     ))
 }
@@ -1237,7 +1187,6 @@ fn total_widget_width() -> i32 {
                     s.show_claude_code,
                     s.show_codex,
                     s.show_antigravity,
-                    s.show_minimax,
                     s.show_ollama,
                 )
             })
@@ -1260,10 +1209,6 @@ fn codex_accent_color(is_dark: bool) -> Color {
 
 fn antigravity_accent_color() -> Color {
     Color::from_hex("#4285F4")
-}
-
-fn minimax_accent_color() -> Color {
-    Color::from_hex("#FF6B35")
 }
 
 fn ollama_accent_color() -> Color {
@@ -1291,14 +1236,6 @@ fn antigravity_usage_text_color(is_dark: bool) -> Color {
         Color::from_hex("#8AB4F8")
     } else {
         Color::from_hex("#1967D2")
-    }
-}
-
-fn minimax_usage_text_color(is_dark: bool) -> Color {
-    if is_dark {
-        Color::from_hex("#FF8C66")
-    } else {
-        Color::from_hex("#CC4A1A")
     }
 }
 
@@ -1389,7 +1326,6 @@ pub fn run() {
             settings.show_claude_code,
             settings.show_codex,
             settings.show_antigravity,
-            settings.show_minimax,
             settings.show_ollama,
         );
         let hwnd = CreateWindowExW(
@@ -1454,10 +1390,6 @@ pub fn run() {
                 antigravity_session_text: "--".to_string(),
                 antigravity_weekly_percent: 0.0,
                 antigravity_weekly_text: "--".to_string(),
-                minimax_session_percent: 0.0,
-                minimax_session_text: "--".to_string(),
-                minimax_weekly_percent: 0.0,
-                minimax_weekly_text: "--".to_string(),
                 ollama_session_percent: 0.0,
                 ollama_session_text: "--".to_string(),
                 ollama_weekly_percent: 0.0,
@@ -1465,7 +1397,6 @@ pub fn run() {
                 show_claude_code: settings.show_claude_code,
                 show_codex: settings.show_codex,
                 show_antigravity: settings.show_antigravity,
-                show_minimax: settings.show_minimax,
                 show_ollama: settings.show_ollama,
                 data: None,
                 poll_interval_ms: settings.poll_interval_ms,
@@ -1589,10 +1520,6 @@ fn render_layered() {
         antigravity_session_text,
         antigravity_weekly_pct,
         antigravity_weekly_text,
-        minimax_session_pct,
-        minimax_session_text,
-        minimax_weekly_pct,
-        minimax_weekly_text,
         ollama_session_pct,
         ollama_session_text,
         ollama_weekly_pct,
@@ -1600,7 +1527,6 @@ fn render_layered() {
         show_claude_code,
         show_codex,
         show_antigravity,
-        show_minimax,
         show_ollama,
     ) = {
         let state = lock_state();
@@ -1622,10 +1548,6 @@ fn render_layered() {
                 s.antigravity_session_text.clone(),
                 s.antigravity_weekly_percent,
                 s.antigravity_weekly_text.clone(),
-                s.minimax_session_percent,
-                s.minimax_session_text.clone(),
-                s.minimax_weekly_percent,
-                s.minimax_weekly_text.clone(),
                 s.ollama_session_percent,
                 s.ollama_session_text.clone(),
                 s.ollama_weekly_percent,
@@ -1633,7 +1555,6 @@ fn render_layered() {
                 s.show_claude_code,
                 s.show_codex,
                 s.show_antigravity,
-                s.show_minimax,
                 s.show_ollama,
             ),
             None => return,
@@ -1656,7 +1577,6 @@ fn render_layered() {
     let accent = claude_accent_color();
     let codex_accent = codex_accent_color(is_dark);
     let antigravity_accent = antigravity_accent_color();
-    let minimax_accent = minimax_accent_color();
     let ollama_accent = ollama_accent_color();
     let track = if is_dark {
         Color::from_hex("#444444")
@@ -1729,10 +1649,6 @@ fn render_layered() {
             &antigravity_session_text,
             antigravity_weekly_pct,
             &antigravity_weekly_text,
-            minimax_session_pct,
-            &minimax_session_text,
-            minimax_weekly_pct,
-            &minimax_weekly_text,
             ollama_session_pct,
             &ollama_session_text,
             ollama_weekly_pct,
@@ -1740,11 +1656,9 @@ fn render_layered() {
             show_claude_code,
             show_codex,
             show_antigravity,
-            show_minimax,
             show_ollama,
             &codex_accent,
             &antigravity_accent,
-            &minimax_accent,
             &ollama_accent,
         );
 
@@ -1817,10 +1731,6 @@ fn paint_content(
     antigravity_session_text: &str,
     antigravity_weekly_pct: f64,
     antigravity_weekly_text: &str,
-    minimax_session_pct: f64,
-    minimax_session_text: &str,
-    minimax_weekly_pct: f64,
-    minimax_weekly_text: &str,
     ollama_session_pct: f64,
     ollama_session_text: &str,
     ollama_weekly_pct: f64,
@@ -1828,11 +1738,9 @@ fn paint_content(
     show_claude_code: bool,
     show_codex: bool,
     show_antigravity: bool,
-    show_minimax: bool,
     show_ollama: bool,
     codex_accent: &Color,
     antigravity_accent: &Color,
-    minimax_accent: &Color,
     ollama_accent: &Color,
 ) {
     unsafe {
@@ -1923,19 +1831,15 @@ fn paint_content(
             codex_session_text,
             antigravity_session_pct,
             antigravity_session_text,
-            minimax_session_pct,
-            minimax_session_text,
             ollama_session_pct,
             ollama_session_text,
             show_claude_code,
             show_codex,
             show_antigravity,
-            show_minimax,
             show_ollama,
             accent,
             codex_accent,
             antigravity_accent,
-            minimax_accent,
             ollama_accent,
             track,
         );
@@ -1952,19 +1856,15 @@ fn paint_content(
             codex_weekly_text,
             antigravity_weekly_pct,
             antigravity_weekly_text,
-            minimax_weekly_pct,
-            minimax_weekly_text,
             ollama_weekly_pct,
             ollama_weekly_text,
             show_claude_code,
             show_codex,
             show_antigravity,
-            show_minimax,
             show_ollama,
             accent,
             codex_accent,
             antigravity_accent,
-            minimax_accent,
             ollama_accent,
             track,
         );
@@ -1980,7 +1880,6 @@ fn do_poll(send_hwnd: SendHwnd) {
         show_claude_code,
         show_codex,
         show_antigravity,
-        show_minimax,
         show_ollama,
     ) = {
         let state = lock_state();
@@ -1990,13 +1889,17 @@ fn do_poll(send_hwnd: SendHwnd) {
                 s.show_claude_code,
                 s.show_codex,
                 s.show_antigravity,
-                s.show_minimax,
                 s.show_ollama,
             ))
-            .unwrap_or((true, false, false, false, false))
+            .unwrap_or((true, false, false, false))
     };
 
-    match poller::poll(show_claude_code, show_codex, show_antigravity, show_minimax, show_ollama) {
+        match poller::poll(
+        show_claude_code,
+        show_codex,
+        show_antigravity,
+        show_ollama,
+    ) {
         Ok(data) => {
             let mut state = lock_state();
             if let Some(s) = state.as_mut() {
@@ -2020,13 +1923,6 @@ fn do_poll(send_hwnd: SendHwnd) {
                 } else if s.show_antigravity {
                     s.antigravity_session_percent = 0.0;
                     s.antigravity_weekly_percent = 0.0;
-                }
-                if let Some(minimax) = data.minimax.as_ref() {
-                    s.minimax_session_percent = minimax.session.percentage;
-                    s.minimax_weekly_percent = minimax.weekly.percentage;
-                } else if s.show_minimax {
-                    s.minimax_session_percent = 0.0;
-                    s.minimax_weekly_percent = 0.0;
                 }
                 if let Some(ollama) = data.ollama.as_ref() {
                     s.ollama_session_percent = ollama.session.percentage;
@@ -2070,7 +1966,6 @@ fn do_poll(send_hwnd: SendHwnd) {
                     if show_antigravity
                         && !show_claude_code
                         && !show_codex
-                        && !show_minimax
                         && !show_ollama =>
                 {
                     Some((
@@ -2110,8 +2005,6 @@ fn do_poll(send_hwnd: SendHwnd) {
                             s.codex_weekly_text = "!".to_string();
                             s.antigravity_session_text = "!".to_string();
                             s.antigravity_weekly_text = "!".to_string();
-                            s.minimax_session_text = "!".to_string();
-                            s.minimax_weekly_text = "!".to_string();
                             s.ollama_session_text = "!".to_string();
                             s.ollama_weekly_text = "!".to_string();
                             s.retry_count = s.retry_count.saturating_add(1);
@@ -2134,8 +2027,6 @@ fn do_poll(send_hwnd: SendHwnd) {
                             s.codex_weekly_text = "...".to_string();
                             s.antigravity_session_text = "...".to_string();
                             s.antigravity_weekly_text = "...".to_string();
-                            s.minimax_session_text = "...".to_string();
-                            s.minimax_weekly_text = "...".to_string();
                             s.ollama_session_text = "...".to_string();
                             s.ollama_weekly_text = "...".to_string();
                             s.retry_count = s.retry_count.saturating_add(1);
@@ -2854,7 +2745,6 @@ unsafe extern "system" fn wnd_proc(
                 IDM_MODEL_CLAUDE_CODE
                 | IDM_MODEL_CODEX
                 | IDM_MODEL_ANTIGRAVITY
-                | IDM_MODEL_MINIMAX
                 | IDM_MODEL_OLLAMA => {
                     {
                         let mut state = lock_state();
@@ -2863,7 +2753,6 @@ unsafe extern "system" fn wnd_proc(
                                 IDM_MODEL_CLAUDE_CODE => {
                                     if s.show_codex
                                         || s.show_antigravity
-                                        || s.show_minimax
                                         || s.show_ollama
                                         || !s.show_claude_code
                                     {
@@ -2873,7 +2762,6 @@ unsafe extern "system" fn wnd_proc(
                                 IDM_MODEL_CODEX => {
                                     if s.show_claude_code
                                         || s.show_antigravity
-                                        || s.show_minimax
                                         || s.show_ollama
                                         || !s.show_codex
                                     {
@@ -2883,28 +2771,16 @@ unsafe extern "system" fn wnd_proc(
                                 IDM_MODEL_ANTIGRAVITY => {
                                     if s.show_claude_code
                                         || s.show_codex
-                                        || s.show_minimax
                                         || s.show_ollama
                                         || !s.show_antigravity
                                     {
                                         s.show_antigravity = !s.show_antigravity;
                                     }
                                 }
-                                IDM_MODEL_MINIMAX => {
-                                    if s.show_claude_code
-                                        || s.show_codex
-                                        || s.show_antigravity
-                                        || s.show_ollama
-                                        || !s.show_minimax
-                                    {
-                                        s.show_minimax = !s.show_minimax;
-                                    }
-                                }
                                 IDM_MODEL_OLLAMA => {
                                     if s.show_claude_code
                                         || s.show_codex
                                         || s.show_antigravity
-                                        || s.show_minimax
                                         || !s.show_ollama
                                     {
                                         s.show_ollama = !s.show_ollama;
@@ -2918,8 +2794,6 @@ unsafe extern "system" fn wnd_proc(
                             s.codex_weekly_text = "...".to_string();
                             s.antigravity_session_text = "...".to_string();
                             s.antigravity_weekly_text = "...".to_string();
-                            s.minimax_session_text = "...".to_string();
-                            s.minimax_weekly_text = "...".to_string();
                             s.ollama_session_text = "...".to_string();
                             s.ollama_weekly_text = "...".to_string();
                         }
@@ -3030,7 +2904,6 @@ fn show_context_menu(hwnd: HWND) {
             show_claude_code,
             show_codex,
             show_antigravity,
-            show_minimax,
             show_ollama,
         ) = {
             let state = lock_state();
@@ -3046,7 +2919,6 @@ fn show_context_menu(hwnd: HWND) {
                     s.show_claude_code,
                     s.show_codex,
                     s.show_antigravity,
-                    s.show_minimax,
                     s.show_ollama,
                 ),
                 None => (
@@ -3058,7 +2930,6 @@ fn show_context_menu(hwnd: HWND) {
                     UpdateStatus::Idle,
                     true,
                     true,
-                    false,
                     false,
                     false,
                     false,
@@ -3146,19 +3017,6 @@ fn show_context_menu(hwnd: HWND) {
             antigravity_flags,
             IDM_MODEL_ANTIGRAVITY as usize,
             PCWSTR::from_raw(antigravity_model.as_ptr()),
-        );
-
-        let minimax_model = native_interop::wide_str(strings.minimax_model);
-        let minimax_flags = if show_minimax {
-            MF_CHECKED
-        } else {
-            MENU_ITEM_FLAGS(0)
-        };
-        let _ = AppendMenuW(
-            models_menu,
-            minimax_flags,
-            IDM_MODEL_MINIMAX as usize,
-            PCWSTR::from_raw(minimax_model.as_ptr()),
         );
 
         let ollama_model = native_interop::wide_str(strings.ollama_model);
@@ -3351,10 +3209,6 @@ fn paint(hdc: HDC, hwnd: HWND) {
         antigravity_session_text,
         antigravity_weekly_pct,
         antigravity_weekly_text,
-        minimax_session_pct,
-        minimax_session_text,
-        minimax_weekly_pct,
-        minimax_weekly_text,
         ollama_session_pct,
         ollama_session_text,
         ollama_weekly_pct,
@@ -3362,7 +3216,6 @@ fn paint(hdc: HDC, hwnd: HWND) {
         show_claude_code,
         show_codex,
         show_antigravity,
-        show_minimax,
         show_ollama,
     ) = {
         let state = lock_state();
@@ -3382,10 +3235,6 @@ fn paint(hdc: HDC, hwnd: HWND) {
                 s.antigravity_session_text.clone(),
                 s.antigravity_weekly_percent,
                 s.antigravity_weekly_text.clone(),
-                s.minimax_session_percent,
-                s.minimax_session_text.clone(),
-                s.minimax_weekly_percent,
-                s.minimax_weekly_text.clone(),
                 s.ollama_session_percent,
                 s.ollama_session_text.clone(),
                 s.ollama_weekly_percent,
@@ -3393,7 +3242,6 @@ fn paint(hdc: HDC, hwnd: HWND) {
                 s.show_claude_code,
                 s.show_codex,
                 s.show_antigravity,
-                s.show_minimax,
                 s.show_ollama,
             ),
             None => return,
@@ -3403,7 +3251,6 @@ fn paint(hdc: HDC, hwnd: HWND) {
     let accent = claude_accent_color();
     let codex_accent = codex_accent_color(is_dark);
     let antigravity_accent = antigravity_accent_color();
-    let minimax_accent = minimax_accent_color();
     let ollama_accent = ollama_accent_color();
     let track = if is_dark {
         Color::from_hex("#444444")
@@ -3457,10 +3304,6 @@ fn paint(hdc: HDC, hwnd: HWND) {
             &antigravity_session_text,
             antigravity_weekly_pct,
             &antigravity_weekly_text,
-            minimax_session_pct,
-            &minimax_session_text,
-            minimax_weekly_pct,
-            &minimax_weekly_text,
             ollama_session_pct,
             &ollama_session_text,
             ollama_weekly_pct,
@@ -3468,11 +3311,9 @@ fn paint(hdc: HDC, hwnd: HWND) {
             show_claude_code,
             show_codex,
             show_antigravity,
-            show_minimax,
             show_ollama,
             &codex_accent,
             &antigravity_accent,
-            &minimax_accent,
             &ollama_accent,
         );
 
@@ -3497,25 +3338,21 @@ fn draw_row(
     codex_text: &str,
     antigravity_percent: f64,
     antigravity_text: &str,
-    minimax_percent: f64,
-    minimax_text: &str,
     ollama_percent: f64,
     ollama_text: &str,
     show_claude_code: bool,
     show_codex: bool,
     show_antigravity: bool,
-    show_minimax: bool,
     show_ollama: bool,
     claude_accent: &Color,
     codex_accent: &Color,
     antigravity_accent: &Color,
-    minimax_accent: &Color,
     ollama_accent: &Color,
     track: &Color,
 ) {
     let seg_h = sc(SEGMENT_H);
     let active_models =
-        active_model_count(show_claude_code, show_codex, show_antigravity, show_minimax, show_ollama);
+        active_model_count(show_claude_code, show_codex, show_antigravity, show_ollama);
     let segment_count = row_bar_segment_count(active_models);
     let use_model_text_colors = active_models > 1;
     let claude_value_color = if use_model_text_colors {
@@ -3530,11 +3367,6 @@ fn draw_row(
     };
     let antigravity_value_color = if use_model_text_colors {
         antigravity_usage_text_color(is_dark)
-    } else {
-        *text_color
-    };
-    let minimax_value_color = if use_model_text_colors {
-        minimax_usage_text_color(is_dark)
     } else {
         *text_color
     };
@@ -3600,20 +3432,6 @@ fn draw_row(
                 antigravity_accent,
                 track,
                 &antigravity_value_color,
-            );
-            model_x += model_usage_width(segment_count) + sc(MODEL_RIGHT_MARGIN);
-        }
-        if show_minimax {
-            draw_usage_bar(
-                hdc,
-                model_x,
-                y,
-                segment_count,
-                minimax_percent,
-                minimax_text,
-                minimax_accent,
-                track,
-                &minimax_value_color,
             );
             model_x += model_usage_width(segment_count) + sc(MODEL_RIGHT_MARGIN);
         }

--- a/src/window.rs
+++ b/src/window.rs
@@ -67,9 +67,19 @@ struct AppState {
     antigravity_session_text: String,
     antigravity_weekly_percent: f64,
     antigravity_weekly_text: String,
+    minimax_session_percent: f64,
+    minimax_session_text: String,
+    minimax_weekly_percent: f64,
+    minimax_weekly_text: String,
+    ollama_session_percent: f64,
+    ollama_session_text: String,
+    ollama_weekly_percent: f64,
+    ollama_weekly_text: String,
     show_claude_code: bool,
     show_codex: bool,
     show_antigravity: bool,
+    show_minimax: bool,
+    show_ollama: bool,
 
     data: Option<AppUsageData>,
 
@@ -132,6 +142,10 @@ const IDM_LANG_SIMPLIFIED_CHINESE: u16 = 51;
 const IDM_MODEL_CLAUDE_CODE: u16 = 60;
 const IDM_MODEL_CODEX: u16 = 61;
 const IDM_MODEL_ANTIGRAVITY: u16 = 62;
+const IDM_MODEL_MINIMAX: u16 = 63;
+const IDM_MODEL_OLLAMA: u16 = 64;
+#[cfg(feature = "ollama-login-webview")]
+const IDM_LOGIN_OLLAMA: u16 = 65;
 
 const WM_DPICHANGED_MSG: u32 = 0x02E0;
 const WM_APP_UPDATE_CHECK_COMPLETE: u32 = WM_APP + 2;
@@ -317,6 +331,10 @@ struct SettingsFile {
     show_codex: bool,
     #[serde(default = "default_show_antigravity")]
     show_antigravity: bool,
+    #[serde(default = "default_show_minimax")]
+    show_minimax: bool,
+    #[serde(default = "default_show_ollama")]
+    show_ollama: bool,
 }
 
 impl Default for SettingsFile {
@@ -331,6 +349,8 @@ impl Default for SettingsFile {
             show_claude_code: true,
             show_codex: false,
             show_antigravity: false,
+            show_minimax: false,
+            show_ollama: false,
         }
     }
 }
@@ -355,13 +375,26 @@ fn default_show_antigravity() -> bool {
     false
 }
 
+fn default_show_minimax() -> bool {
+    false
+}
+
+fn default_show_ollama() -> bool {
+    false
+}
+
 fn load_settings() -> SettingsFile {
     let content = match std::fs::read_to_string(settings_path()) {
         Ok(c) => c,
         Err(_) => return SettingsFile::default(),
     };
     let mut settings: SettingsFile = serde_json::from_str(&content).unwrap_or_default();
-    if !settings.show_claude_code && !settings.show_codex && !settings.show_antigravity {
+    if !settings.show_claude_code
+        && !settings.show_codex
+        && !settings.show_antigravity
+        && !settings.show_minimax
+        && !settings.show_ollama
+    {
         settings.show_claude_code = true;
     }
     settings
@@ -392,6 +425,8 @@ fn save_state_settings() {
             show_claude_code: s.show_claude_code,
             show_codex: s.show_codex,
             show_antigravity: s.show_antigravity,
+            show_minimax: s.show_minimax,
+            show_ollama: s.show_ollama,
         });
     }
 }
@@ -437,6 +472,30 @@ fn tray_icon_data_from_state() -> Vec<tray_icon::TrayIconData> {
                     ),
                 });
             }
+            if s.show_minimax {
+                icons.push(tray_icon::TrayIconData {
+                    kind: tray_icon::TrayIconKind::Antigravity,
+                    percent: Some(s.minimax_session_percent),
+                    tooltip: format!(
+                        "{} 5h: {} | 7d: {}",
+                        s.language.strings().minimax_model,
+                        s.minimax_session_text,
+                        s.minimax_weekly_text
+                    ),
+                });
+            }
+            if s.show_ollama {
+                icons.push(tray_icon::TrayIconData {
+                    kind: tray_icon::TrayIconKind::Antigravity,
+                    percent: Some(s.ollama_session_percent),
+                    tooltip: format!(
+                        "{} 5h: {} | 7d: {}",
+                        s.language.strings().ollama_model,
+                        s.ollama_session_text,
+                        s.ollama_weekly_text
+                    ),
+                });
+            }
             icons
         }
         Some(s) => {
@@ -460,6 +519,20 @@ fn tray_icon_data_from_state() -> Vec<tray_icon::TrayIconData> {
                     kind: tray_icon::TrayIconKind::Antigravity,
                     percent: None,
                     tooltip: s.language.strings().antigravity_window_title.to_string(),
+                });
+            }
+            if s.show_minimax {
+                icons.push(tray_icon::TrayIconData {
+                    kind: tray_icon::TrayIconKind::Antigravity,
+                    percent: None,
+                    tooltip: s.language.strings().minimax_window_title.to_string(),
+                });
+            }
+            if s.show_ollama {
+                icons.push(tray_icon::TrayIconData {
+                    kind: tray_icon::TrayIconKind::Antigravity,
+                    percent: None,
+                    tooltip: s.language.strings().ollama_window_title.to_string(),
                 });
             }
             icons
@@ -672,6 +745,32 @@ fn refresh_usage_texts(state: &mut AppState) {
     } else if state.show_antigravity {
         state.antigravity_session_text = "!".to_string();
         state.antigravity_weekly_text = "!".to_string();
+    }
+
+    if let Some(minimax) = data.minimax.as_ref() {
+        state.minimax_session_text = poller::format_line(&minimax.session, strings);
+        state.minimax_weekly_text =
+            if minimax.weekly.resets_at.is_none() && minimax.weekly.percentage == 0.0 {
+                "--".to_string()
+            } else {
+                poller::format_line(&minimax.weekly, strings)
+            };
+    } else if state.show_minimax {
+        state.minimax_session_text = "!".to_string();
+        state.minimax_weekly_text = "!".to_string();
+    }
+
+    if let Some(ollama) = data.ollama.as_ref() {
+        state.ollama_session_text = poller::format_line(&ollama.session, strings);
+        state.ollama_weekly_text =
+            if ollama.weekly.resets_at.is_none() && ollama.weekly.percentage == 0.0 {
+                "--".to_string()
+            } else {
+                poller::format_line(&ollama.weekly, strings)
+            };
+    } else if state.show_ollama {
+        state.ollama_session_text = "!".to_string();
+        state.ollama_weekly_text = "!".to_string();
     }
 }
 
@@ -1080,8 +1179,19 @@ fn cursor_is_on_drag_handle(hwnd: HWND) -> bool {
     }
 }
 
-fn active_model_count(show_claude_code: bool, show_codex: bool, show_antigravity: bool) -> i32 {
-    (show_claude_code as i32 + show_codex as i32 + show_antigravity as i32).max(1)
+fn active_model_count(
+    show_claude_code: bool,
+    show_codex: bool,
+    show_antigravity: bool,
+    show_minimax: bool,
+    show_ollama: bool,
+) -> i32 {
+    (show_claude_code as i32
+        + show_codex as i32
+        + show_antigravity as i32
+        + show_minimax as i32
+        + show_ollama as i32)
+        .max(1)
 }
 
 fn row_bar_segment_count(active_models: i32) -> i32 {
@@ -1112,6 +1222,8 @@ fn total_widget_width_for_state(state: &AppState) -> i32 {
         state.show_claude_code,
         state.show_codex,
         state.show_antigravity,
+        state.show_minimax,
+        state.show_ollama,
     ))
 }
 
@@ -1120,7 +1232,15 @@ fn total_widget_width() -> i32 {
         let state = lock_state();
         state
             .as_ref()
-            .map(|s| active_model_count(s.show_claude_code, s.show_codex, s.show_antigravity))
+            .map(|s| {
+                active_model_count(
+                    s.show_claude_code,
+                    s.show_codex,
+                    s.show_antigravity,
+                    s.show_minimax,
+                    s.show_ollama,
+                )
+            })
             .unwrap_or(1)
     };
     total_widget_width_for(active_models)
@@ -1140,6 +1260,14 @@ fn codex_accent_color(is_dark: bool) -> Color {
 
 fn antigravity_accent_color() -> Color {
     Color::from_hex("#4285F4")
+}
+
+fn minimax_accent_color() -> Color {
+    Color::from_hex("#FF6B35")
+}
+
+fn ollama_accent_color() -> Color {
+    Color::from_hex("#676BEC")
 }
 
 fn claude_usage_text_color(is_dark: bool) -> Color {
@@ -1163,6 +1291,22 @@ fn antigravity_usage_text_color(is_dark: bool) -> Color {
         Color::from_hex("#8AB4F8")
     } else {
         Color::from_hex("#1967D2")
+    }
+}
+
+fn minimax_usage_text_color(is_dark: bool) -> Color {
+    if is_dark {
+        Color::from_hex("#FF8C66")
+    } else {
+        Color::from_hex("#CC4A1A")
+    }
+}
+
+fn ollama_usage_text_color(is_dark: bool) -> Color {
+    if is_dark {
+        Color::from_hex("#9398F5")
+    } else {
+        Color::from_hex("#4848B8")
     }
 }
 
@@ -1245,6 +1389,8 @@ pub fn run() {
             settings.show_claude_code,
             settings.show_codex,
             settings.show_antigravity,
+            settings.show_minimax,
+            settings.show_ollama,
         );
         let hwnd = CreateWindowExW(
             WS_EX_TOOLWINDOW | WS_EX_LAYERED | WS_EX_NOACTIVATE,
@@ -1308,9 +1454,19 @@ pub fn run() {
                 antigravity_session_text: "--".to_string(),
                 antigravity_weekly_percent: 0.0,
                 antigravity_weekly_text: "--".to_string(),
+                minimax_session_percent: 0.0,
+                minimax_session_text: "--".to_string(),
+                minimax_weekly_percent: 0.0,
+                minimax_weekly_text: "--".to_string(),
+                ollama_session_percent: 0.0,
+                ollama_session_text: "--".to_string(),
+                ollama_weekly_percent: 0.0,
+                ollama_weekly_text: "--".to_string(),
                 show_claude_code: settings.show_claude_code,
                 show_codex: settings.show_codex,
                 show_antigravity: settings.show_antigravity,
+                show_minimax: settings.show_minimax,
+                show_ollama: settings.show_ollama,
                 data: None,
                 poll_interval_ms: settings.poll_interval_ms,
                 retry_count: 0,
@@ -1433,9 +1589,19 @@ fn render_layered() {
         antigravity_session_text,
         antigravity_weekly_pct,
         antigravity_weekly_text,
+        minimax_session_pct,
+        minimax_session_text,
+        minimax_weekly_pct,
+        minimax_weekly_text,
+        ollama_session_pct,
+        ollama_session_text,
+        ollama_weekly_pct,
+        ollama_weekly_text,
         show_claude_code,
         show_codex,
         show_antigravity,
+        show_minimax,
+        show_ollama,
     ) = {
         let state = lock_state();
         match state.as_ref() {
@@ -1456,9 +1622,19 @@ fn render_layered() {
                 s.antigravity_session_text.clone(),
                 s.antigravity_weekly_percent,
                 s.antigravity_weekly_text.clone(),
+                s.minimax_session_percent,
+                s.minimax_session_text.clone(),
+                s.minimax_weekly_percent,
+                s.minimax_weekly_text.clone(),
+                s.ollama_session_percent,
+                s.ollama_session_text.clone(),
+                s.ollama_weekly_percent,
+                s.ollama_weekly_text.clone(),
                 s.show_claude_code,
                 s.show_codex,
                 s.show_antigravity,
+                s.show_minimax,
+                s.show_ollama,
             ),
             None => return,
         }
@@ -1480,6 +1656,8 @@ fn render_layered() {
     let accent = claude_accent_color();
     let codex_accent = codex_accent_color(is_dark);
     let antigravity_accent = antigravity_accent_color();
+    let minimax_accent = minimax_accent_color();
+    let ollama_accent = ollama_accent_color();
     let track = if is_dark {
         Color::from_hex("#444444")
     } else {
@@ -1551,11 +1729,23 @@ fn render_layered() {
             &antigravity_session_text,
             antigravity_weekly_pct,
             &antigravity_weekly_text,
+            minimax_session_pct,
+            &minimax_session_text,
+            minimax_weekly_pct,
+            &minimax_weekly_text,
+            ollama_session_pct,
+            &ollama_session_text,
+            ollama_weekly_pct,
+            &ollama_weekly_text,
             show_claude_code,
             show_codex,
             show_antigravity,
+            show_minimax,
+            show_ollama,
             &codex_accent,
             &antigravity_accent,
+            &minimax_accent,
+            &ollama_accent,
         );
 
         // Background pixels → alpha 1 (nearly invisible but still hittable for right-click).
@@ -1627,11 +1817,23 @@ fn paint_content(
     antigravity_session_text: &str,
     antigravity_weekly_pct: f64,
     antigravity_weekly_text: &str,
+    minimax_session_pct: f64,
+    minimax_session_text: &str,
+    minimax_weekly_pct: f64,
+    minimax_weekly_text: &str,
+    ollama_session_pct: f64,
+    ollama_session_text: &str,
+    ollama_weekly_pct: f64,
+    ollama_weekly_text: &str,
     show_claude_code: bool,
     show_codex: bool,
     show_antigravity: bool,
+    show_minimax: bool,
+    show_ollama: bool,
     codex_accent: &Color,
     antigravity_accent: &Color,
+    minimax_accent: &Color,
+    ollama_accent: &Color,
 ) {
     unsafe {
         let client_rect = RECT {
@@ -1721,12 +1923,20 @@ fn paint_content(
             codex_session_text,
             antigravity_session_pct,
             antigravity_session_text,
+            minimax_session_pct,
+            minimax_session_text,
+            ollama_session_pct,
+            ollama_session_text,
             show_claude_code,
             show_codex,
             show_antigravity,
+            show_minimax,
+            show_ollama,
             accent,
             codex_accent,
             antigravity_accent,
+            minimax_accent,
+            ollama_accent,
             track,
         );
         draw_row(
@@ -1742,12 +1952,20 @@ fn paint_content(
             codex_weekly_text,
             antigravity_weekly_pct,
             antigravity_weekly_text,
+            minimax_weekly_pct,
+            minimax_weekly_text,
+            ollama_weekly_pct,
+            ollama_weekly_text,
             show_claude_code,
             show_codex,
             show_antigravity,
+            show_minimax,
+            show_ollama,
             accent,
             codex_accent,
             antigravity_accent,
+            minimax_accent,
+            ollama_accent,
             track,
         );
 
@@ -1758,15 +1976,27 @@ fn paint_content(
 
 fn do_poll(send_hwnd: SendHwnd) {
     let hwnd = send_hwnd.to_hwnd();
-    let (show_claude_code, show_codex, show_antigravity) = {
+    let (
+        show_claude_code,
+        show_codex,
+        show_antigravity,
+        show_minimax,
+        show_ollama,
+    ) = {
         let state = lock_state();
         state
             .as_ref()
-            .map(|s| (s.show_claude_code, s.show_codex, s.show_antigravity))
-            .unwrap_or((true, false, false))
+            .map(|s| (
+                s.show_claude_code,
+                s.show_codex,
+                s.show_antigravity,
+                s.show_minimax,
+                s.show_ollama,
+            ))
+            .unwrap_or((true, false, false, false, false))
     };
 
-    match poller::poll(show_claude_code, show_codex, show_antigravity) {
+    match poller::poll(show_claude_code, show_codex, show_antigravity, show_minimax, show_ollama) {
         Ok(data) => {
             let mut state = lock_state();
             if let Some(s) = state.as_mut() {
@@ -1790,6 +2020,20 @@ fn do_poll(send_hwnd: SendHwnd) {
                 } else if s.show_antigravity {
                     s.antigravity_session_percent = 0.0;
                     s.antigravity_weekly_percent = 0.0;
+                }
+                if let Some(minimax) = data.minimax.as_ref() {
+                    s.minimax_session_percent = minimax.session.percentage;
+                    s.minimax_weekly_percent = minimax.weekly.percentage;
+                } else if s.show_minimax {
+                    s.minimax_session_percent = 0.0;
+                    s.minimax_weekly_percent = 0.0;
+                }
+                if let Some(ollama) = data.ollama.as_ref() {
+                    s.ollama_session_percent = ollama.session.percentage;
+                    s.ollama_weekly_percent = ollama.weekly.percentage;
+                } else if s.show_ollama {
+                    s.ollama_session_percent = 0.0;
+                    s.ollama_weekly_percent = 0.0;
                 }
                 // Stop fast-poll if reset data is now fresh
                 if !poller::app_is_past_reset(&data) {
@@ -1823,7 +2067,11 @@ fn do_poll(send_hwnd: SendHwnd) {
         Err(e) => {
             let auth_watch = match e {
                 poller::PollError::AuthRequired | poller::PollError::TokenExpired
-                    if show_antigravity && !show_claude_code && !show_codex =>
+                    if show_antigravity
+                        && !show_claude_code
+                        && !show_codex
+                        && !show_minimax
+                        && !show_ollama =>
                 {
                     Some((
                         poller::CredentialWatchMode::Antigravity,
@@ -1862,6 +2110,10 @@ fn do_poll(send_hwnd: SendHwnd) {
                             s.codex_weekly_text = "!".to_string();
                             s.antigravity_session_text = "!".to_string();
                             s.antigravity_weekly_text = "!".to_string();
+                            s.minimax_session_text = "!".to_string();
+                            s.minimax_weekly_text = "!".to_string();
+                            s.ollama_session_text = "!".to_string();
+                            s.ollama_weekly_text = "!".to_string();
                             s.retry_count = s.retry_count.saturating_add(1);
                             unsafe {
                                 let _ = KillTimer(hwnd, TIMER_POLL);
@@ -1882,6 +2134,10 @@ fn do_poll(send_hwnd: SendHwnd) {
                             s.codex_weekly_text = "...".to_string();
                             s.antigravity_session_text = "...".to_string();
                             s.antigravity_weekly_text = "...".to_string();
+                            s.minimax_session_text = "...".to_string();
+                            s.minimax_weekly_text = "...".to_string();
+                            s.ollama_session_text = "...".to_string();
+                            s.ollama_weekly_text = "...".to_string();
                             s.retry_count = s.retry_count.saturating_add(1);
                             let backoff = RETRY_BASE_MS.saturating_mul(
                                 1u32.checked_shl(s.retry_count - 1).unwrap_or(u32::MAX),
@@ -2595,24 +2851,63 @@ unsafe extern "system" fn wnd_proc(
                     // Reset the poll timer with the new interval
                     SetTimer(hwnd, TIMER_POLL, new_interval, None);
                 }
-                IDM_MODEL_CLAUDE_CODE | IDM_MODEL_CODEX | IDM_MODEL_ANTIGRAVITY => {
+                IDM_MODEL_CLAUDE_CODE
+                | IDM_MODEL_CODEX
+                | IDM_MODEL_ANTIGRAVITY
+                | IDM_MODEL_MINIMAX
+                | IDM_MODEL_OLLAMA => {
                     {
                         let mut state = lock_state();
                         if let Some(s) = state.as_mut() {
                             match id {
                                 IDM_MODEL_CLAUDE_CODE => {
-                                    if s.show_codex || s.show_antigravity || !s.show_claude_code {
+                                    if s.show_codex
+                                        || s.show_antigravity
+                                        || s.show_minimax
+                                        || s.show_ollama
+                                        || !s.show_claude_code
+                                    {
                                         s.show_claude_code = !s.show_claude_code;
                                     }
                                 }
                                 IDM_MODEL_CODEX => {
-                                    if s.show_claude_code || s.show_antigravity || !s.show_codex {
+                                    if s.show_claude_code
+                                        || s.show_antigravity
+                                        || s.show_minimax
+                                        || s.show_ollama
+                                        || !s.show_codex
+                                    {
                                         s.show_codex = !s.show_codex;
                                     }
                                 }
                                 IDM_MODEL_ANTIGRAVITY => {
-                                    if s.show_claude_code || s.show_codex || !s.show_antigravity {
+                                    if s.show_claude_code
+                                        || s.show_codex
+                                        || s.show_minimax
+                                        || s.show_ollama
+                                        || !s.show_antigravity
+                                    {
                                         s.show_antigravity = !s.show_antigravity;
+                                    }
+                                }
+                                IDM_MODEL_MINIMAX => {
+                                    if s.show_claude_code
+                                        || s.show_codex
+                                        || s.show_antigravity
+                                        || s.show_ollama
+                                        || !s.show_minimax
+                                    {
+                                        s.show_minimax = !s.show_minimax;
+                                    }
+                                }
+                                IDM_MODEL_OLLAMA => {
+                                    if s.show_claude_code
+                                        || s.show_codex
+                                        || s.show_antigravity
+                                        || s.show_minimax
+                                        || !s.show_ollama
+                                    {
+                                        s.show_ollama = !s.show_ollama;
                                     }
                                 }
                                 _ => {}
@@ -2623,6 +2918,10 @@ unsafe extern "system" fn wnd_proc(
                             s.codex_weekly_text = "...".to_string();
                             s.antigravity_session_text = "...".to_string();
                             s.antigravity_weekly_text = "...".to_string();
+                            s.minimax_session_text = "...".to_string();
+                            s.minimax_weekly_text = "...".to_string();
+                            s.ollama_session_text = "...".to_string();
+                            s.ollama_weekly_text = "...".to_string();
                         }
                     }
                     save_state_settings();
@@ -2633,6 +2932,19 @@ unsafe extern "system" fn wnd_proc(
                     std::thread::spawn(move || {
                         do_poll(sh);
                     });
+                }
+                #[cfg(feature = "ollama-login-webview")]
+                IDM_LOGIN_OLLAMA => {
+                    tray_icon::notify_balloon(
+                        hwnd,
+                        tray_icon::TrayIconKind::Claude,
+                        "Ollama login",
+                        "A sign-in window will open. Complete WorkOS auth there; the tray picks up the cookie on the next poll.",
+                    );
+                    // Spawn the standalone helper process. It runs its own
+                    // tao event loop with its own Win32 message pump, so the
+                    // tray stays responsive.
+                    crate::ollama_login::run_login_blocking();
                 }
                 IDM_LANG_SYSTEM
                 | IDM_LANG_ENGLISH
@@ -2718,6 +3030,8 @@ fn show_context_menu(hwnd: HWND) {
             show_claude_code,
             show_codex,
             show_antigravity,
+            show_minimax,
+            show_ollama,
         ) = {
             let state = lock_state();
             match state.as_ref() {
@@ -2732,6 +3046,8 @@ fn show_context_menu(hwnd: HWND) {
                     s.show_claude_code,
                     s.show_codex,
                     s.show_antigravity,
+                    s.show_minimax,
+                    s.show_ollama,
                 ),
                 None => (
                     POLL_15_MIN,
@@ -2742,6 +3058,8 @@ fn show_context_menu(hwnd: HWND) {
                     UpdateStatus::Idle,
                     true,
                     true,
+                    false,
+                    false,
                     false,
                     false,
                 ),
@@ -2829,6 +3147,51 @@ fn show_context_menu(hwnd: HWND) {
             IDM_MODEL_ANTIGRAVITY as usize,
             PCWSTR::from_raw(antigravity_model.as_ptr()),
         );
+
+        let minimax_model = native_interop::wide_str(strings.minimax_model);
+        let minimax_flags = if show_minimax {
+            MF_CHECKED
+        } else {
+            MENU_ITEM_FLAGS(0)
+        };
+        let _ = AppendMenuW(
+            models_menu,
+            minimax_flags,
+            IDM_MODEL_MINIMAX as usize,
+            PCWSTR::from_raw(minimax_model.as_ptr()),
+        );
+
+        let ollama_model = native_interop::wide_str(strings.ollama_model);
+        let ollama_flags = if show_ollama {
+            MF_CHECKED
+        } else {
+            MENU_ITEM_FLAGS(0)
+        };
+        let _ = AppendMenuW(
+            models_menu,
+            ollama_flags,
+            IDM_MODEL_OLLAMA as usize,
+            PCWSTR::from_raw(ollama_model.as_ptr()),
+        );
+
+        // "Log in to Ollama…" menu item — only built when the
+        // `ollama-login-webview` feature is enabled (otherwise no wry/tao).
+        #[cfg(feature = "ollama-login-webview")]
+        {
+            let _ = AppendMenuW(
+                models_menu,
+                MF_SEPARATOR,
+                0,
+                PCWSTR::null(),
+            );
+            let login_str = native_interop::wide_str("Log in to Ollama\u{2026}");
+            let _ = AppendMenuW(
+                models_menu,
+                MENU_ITEM_FLAGS(0),
+                IDM_LOGIN_OLLAMA as usize,
+                PCWSTR::from_raw(login_str.as_ptr()),
+            );
+        }
 
         let models_label = native_interop::wide_str(strings.models);
         let _ = AppendMenuW(
@@ -2988,9 +3351,19 @@ fn paint(hdc: HDC, hwnd: HWND) {
         antigravity_session_text,
         antigravity_weekly_pct,
         antigravity_weekly_text,
+        minimax_session_pct,
+        minimax_session_text,
+        minimax_weekly_pct,
+        minimax_weekly_text,
+        ollama_session_pct,
+        ollama_session_text,
+        ollama_weekly_pct,
+        ollama_weekly_text,
         show_claude_code,
         show_codex,
         show_antigravity,
+        show_minimax,
+        show_ollama,
     ) = {
         let state = lock_state();
         match state.as_ref() {
@@ -3009,9 +3382,19 @@ fn paint(hdc: HDC, hwnd: HWND) {
                 s.antigravity_session_text.clone(),
                 s.antigravity_weekly_percent,
                 s.antigravity_weekly_text.clone(),
+                s.minimax_session_percent,
+                s.minimax_session_text.clone(),
+                s.minimax_weekly_percent,
+                s.minimax_weekly_text.clone(),
+                s.ollama_session_percent,
+                s.ollama_session_text.clone(),
+                s.ollama_weekly_percent,
+                s.ollama_weekly_text.clone(),
                 s.show_claude_code,
                 s.show_codex,
                 s.show_antigravity,
+                s.show_minimax,
+                s.show_ollama,
             ),
             None => return,
         }
@@ -3020,6 +3403,8 @@ fn paint(hdc: HDC, hwnd: HWND) {
     let accent = claude_accent_color();
     let codex_accent = codex_accent_color(is_dark);
     let antigravity_accent = antigravity_accent_color();
+    let minimax_accent = minimax_accent_color();
+    let ollama_accent = ollama_accent_color();
     let track = if is_dark {
         Color::from_hex("#444444")
     } else {
@@ -3072,11 +3457,23 @@ fn paint(hdc: HDC, hwnd: HWND) {
             &antigravity_session_text,
             antigravity_weekly_pct,
             &antigravity_weekly_text,
+            minimax_session_pct,
+            &minimax_session_text,
+            minimax_weekly_pct,
+            &minimax_weekly_text,
+            ollama_session_pct,
+            &ollama_session_text,
+            ollama_weekly_pct,
+            &ollama_weekly_text,
             show_claude_code,
             show_codex,
             show_antigravity,
+            show_minimax,
+            show_ollama,
             &codex_accent,
             &antigravity_accent,
+            &minimax_accent,
+            &ollama_accent,
         );
 
         let _ = BitBlt(hdc, 0, 0, width, height, mem_dc, 0, 0, SRCCOPY);
@@ -3100,16 +3497,25 @@ fn draw_row(
     codex_text: &str,
     antigravity_percent: f64,
     antigravity_text: &str,
+    minimax_percent: f64,
+    minimax_text: &str,
+    ollama_percent: f64,
+    ollama_text: &str,
     show_claude_code: bool,
     show_codex: bool,
     show_antigravity: bool,
+    show_minimax: bool,
+    show_ollama: bool,
     claude_accent: &Color,
     codex_accent: &Color,
     antigravity_accent: &Color,
+    minimax_accent: &Color,
+    ollama_accent: &Color,
     track: &Color,
 ) {
     let seg_h = sc(SEGMENT_H);
-    let active_models = active_model_count(show_claude_code, show_codex, show_antigravity);
+    let active_models =
+        active_model_count(show_claude_code, show_codex, show_antigravity, show_minimax, show_ollama);
     let segment_count = row_bar_segment_count(active_models);
     let use_model_text_colors = active_models > 1;
     let claude_value_color = if use_model_text_colors {
@@ -3124,6 +3530,16 @@ fn draw_row(
     };
     let antigravity_value_color = if use_model_text_colors {
         antigravity_usage_text_color(is_dark)
+    } else {
+        *text_color
+    };
+    let minimax_value_color = if use_model_text_colors {
+        minimax_usage_text_color(is_dark)
+    } else {
+        *text_color
+    };
+    let ollama_value_color = if use_model_text_colors {
+        ollama_usage_text_color(is_dark)
     } else {
         *text_color
     };
@@ -3184,6 +3600,34 @@ fn draw_row(
                 antigravity_accent,
                 track,
                 &antigravity_value_color,
+            );
+            model_x += model_usage_width(segment_count) + sc(MODEL_RIGHT_MARGIN);
+        }
+        if show_minimax {
+            draw_usage_bar(
+                hdc,
+                model_x,
+                y,
+                segment_count,
+                minimax_percent,
+                minimax_text,
+                minimax_accent,
+                track,
+                &minimax_value_color,
+            );
+            model_x += model_usage_width(segment_count) + sc(MODEL_RIGHT_MARGIN);
+        }
+        if show_ollama {
+            draw_usage_bar(
+                hdc,
+                model_x,
+                y,
+                segment_count,
+                ollama_percent,
+                ollama_text,
+                ollama_accent,
+                track,
+                &ollama_value_color,
             );
         }
     }

--- a/src/window.rs
+++ b/src/window.rs
@@ -459,7 +459,7 @@ fn tray_icon_data_from_state() -> Vec<tray_icon::TrayIconData> {
             }
             if s.show_ollama {
                 icons.push(tray_icon::TrayIconData {
-                    kind: tray_icon::TrayIconKind::Antigravity,
+                    kind: tray_icon::TrayIconKind::Ollama,
                     percent: Some(s.ollama_session_percent),
                     tooltip: format!(
                         "{} 5h: {} | 7d: {}",
@@ -496,7 +496,7 @@ fn tray_icon_data_from_state() -> Vec<tray_icon::TrayIconData> {
             }
             if s.show_ollama {
                 icons.push(tray_icon::TrayIconData {
-                    kind: tray_icon::TrayIconKind::Antigravity,
+                    kind: tray_icon::TrayIconKind::Ollama,
                     percent: None,
                     tooltip: s.language.strings().ollama_window_title.to_string(),
                 });
@@ -2061,6 +2061,13 @@ fn do_poll(send_hwnd: SendHwnd) {
                                 tray_icon::TrayIconKind::Codex,
                                 s.language.strings().codex_token_expired_title,
                                 s.language.strings().codex_token_expired_body,
+                            )
+                        } else if s.show_ollama {
+                            (
+                                s.language.strings(),
+                                tray_icon::TrayIconKind::Ollama,
+                                s.language.strings().ollama_token_expired_title,
+                                s.language.strings().ollama_token_expired_body,
                             )
                         } else {
                             (


### PR DESCRIPTION
## Summary

Adds an Ollama Cloud (ollama.com) usage meter alongside the existing Claude Code, Codex, and Antigravity meters. Ollama exposes a quota page at `https://ollama.com/settings` but it is HTML, not an API — the only public Ollama Cloud API key only identifies the plan tier, not consumption — so this PR scrapes the aria-labelled percentages from the authenticated settings page using a captured browser session cookie.

## How the user authenticates

Ollama Cloud auth is WorkOS-hosted; a raw `Cookie:` header from a non-Chrome process fails the session-binding check and returns 303 to `signin.ollama.com`. So this PR includes:

1. **A standalone `ollama-login-helper.exe` process** that opens an embedded WebView2 window (via wry+tao), lets the user complete WorkOS auth, and writes the resulting cookie to `%LOCALAPPDATA%\ClaudeCodeUsageMonitor\ollama_session_cookie.txt`.
2. **A new tray menu item**: right-click → Models → **"Log in to Ollama…"** — feature-gated behind `--features ollama-login-webview` (off by default because wry/tao add ~6 MB to the release binary).
3. **Environment-variable fallback**: setting `OLLAMA_CLOUD_SESSION` in env or `~/.claude/settings.json#env.OLLAMA_CLOUD_SESSION` also works for headless setups.

## What this PR adds

- `src/models.rs`: new optional `ollama` field on `AppUsageData`
- `src/poller.rs`: new `poll_ollama()` + `read_ollama_session_cookie()` + `fetch_ollama_usage()` + `parse_ollama_usage()` that scrape aria-labelled percentages from ollama.com/settings. Parser unit tests included (parses the real page structure, returns `AuthExpired` when logged out, returns `ParseFailed` when structure changes, etc.).
- `src/window.rs`: new bar in the widget, **Models → Ollama** toggle entry, localization entries, draw code. All gated behind the same toggle pattern as the other providers.
- `src/main.rs`: registers the new modules
- `src/ollama_login.rs`: tray-side helper that spawns the webview login process
- `src/ollama_login_helper.rs`: standalone WebView2 process (only built with `--features ollama-login-webview`) that opens an embedded Edge window, captures cookies, writes them to disk, then exits.
- `Cargo.toml`: registers the `ollama-login-webview` feature, optional wry/tao deps, and the second `[[bin]]` target for `ollama-login-helper`
- `src/localization/*`: new `ollama_model` and `ollama_window_title` strings across all 11 language files

## Test plan

- [ ] `cargo test` passes (12/12 verified locally, including the new ollama parser tests)
- [ ] `cargo build --release` clean, no warnings
- [ ] `cargo build --release --features ollama-login-webview` clean
- [ ] Live: tray shows Ollama bar; toggling Models → Ollama shows/hides it and persists across restarts
- [ ] Live: with a captured cookie, the Ollama bar shows the real session/weekly percentages

I verified all of these on Windows 11 locally with the dev account — cookie capture works against ollama.com/settings, returns session=100% and weekly=44.2%.

## Design notes

- Ollama returns an HTML page, not JSON, so I matched the actual aria-label structure with explicit regexes. I added a separate `OllamaParseError` enum so changes to ollama.com layout surface as `PollError::RequestFailed` rather than panicking.
- The webview login is a separate process because wry's `EventLoop::run()` on Windows must own the Win32 message pump — running it inside the tray's `DispatchMessageW` handler starves the event loop and WebView2 doesn't paint.
- The tray process never embeds wry/tao. The helper exe is the only thing that depends on it. Default builds add zero new dependencies.
- The Ollama parser deliberately fails (rather than showing fake zeros) when there's no cookie. The tray displays `!` in the bar to make the missing-auth state obvious.

## Why this is upstream-friendly

- No new runtime dependencies in the default build (wry/tao are feature-gated).
- Parser unit tests cover the happy path, zero-usage, and structure-change cases.
- Cookie capture is non-invasive — the tray just writes a plain text file the poller reads back.

## What's not in this PR

- Fable 5 weekly meter — being handled separately in PR #49.
- minimax / `~/.hermes/auth.json` integration — local-fork feature, depends on Hermes internals, not proposed for upstream.

## Risks

- **Ollama.com layout change** would break parsing. Mitigated by explicit `OllamaParseError::AuthExpired` and `ParseFailed` returning rather than panicking, plus the test fixtures.
- **The cookie is captured in a regular WebView2 process** rather than the user's Chrome profile, so it's a separate session. This is fine for Ollama Cloud auth because Ollama doesn't bind to the browser identity like Anthropic does — only the session cookie matters.

Let me know if you'd like the PR split or merged differently — happy to split out the webview login helper into a follow-up PR if you'd rather review the parsing change alone first.
