### PR TITLE
feat: expose OpenCode monthly usage window to themes

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,8 @@ Data names use the same structure for `claude`, `codex`, `antigravity`, `opencod
 - `providers.count`
 - `providers.claude.enabled`, `providers.codex.enabled`, `providers.antigravity.enabled`, `providers.opencode.enabled`, and `providers.cursor.enabled`
 
+The OpenCode Go provider additionally exposes its monthly window while it is available: `{opencode.monthly.percentage}`, `{opencode.monthly.remaining}`, `{opencode.monthly.label}` (`30d`), `{opencode.monthly.reset.*}`, and `{opencode.monthly.available}` (1 when monthly data is present, otherwise 0). The `weekly` bar keeps its automatic 7d/30d selection unchanged; use `{provider}.monthly.available` in a render expression to show monthly elements only when the dashboard reports a monthly window.
+
 The `providers.*.enabled` values reflect the dashboard settings rather than temporary polling availability, so a provider error does not unexpectedly reflow the widget. For example, `ceil(10 / max(1, providers.count))` produces the classic adaptive segment count.
 
 Text templates insert expressions in braces. For example, `{claude.session.percentage:0.0}%` fixes one decimal place and `{codex.weekly.reset.seconds:duration}` produces a compact countdown. Canvas size is available as `canvas.width` and `canvas.height`.

--- a/src/models.rs
+++ b/src/models.rs
@@ -18,6 +18,10 @@ pub struct UsageData {
     pub weekly: UsageSection,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub weekly_label: Option<String>,
+    /// Optional longer-window usage (e.g. the OpenCode Go monthly window).
+    /// Kept separate from `weekly` so themes can choose how to display it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub monthly: Option<UsageSection>,
 }
 
 #[derive(Clone, Debug, Default, PartialEq)]
@@ -97,6 +101,10 @@ mod tests {
                 ProviderId::OpenCode,
                 UsageData {
                     weekly_label: Some("30d".into()),
+                    monthly: Some(UsageSection {
+                        percentage: 43.0,
+                        resets_at: None,
+                    }),
                     ..Default::default()
                 },
             ),
@@ -108,6 +116,7 @@ mod tests {
         assert!(json.get("claude_code").is_some());
         assert!(json.get("codex").is_some());
         assert_eq!(json["opencode"]["weekly_label"], "30d");
+        assert_eq!(json["opencode"]["monthly"]["percentage"], 43.0);
         assert!(json.get("claude").is_none());
 
         let decoded: AppUsageData = serde_json::from_value(json).unwrap();

--- a/src/poller/antigravity.rs
+++ b/src/poller/antigravity.rs
@@ -171,6 +171,7 @@ pub(super) fn fetch_antigravity_usage_from_endpoint(
         session,
         weekly,
         weekly_label: None,
+        ..Default::default()
     })
 }
 

--- a/src/poller/cursor.rs
+++ b/src/poller/cursor.rs
@@ -232,6 +232,7 @@ fn cursor_usage_from_summary(response: CursorUsageSummaryResponse) -> Option<Usa
             resets_at: reset,
         },
         weekly_label: Some("API".into()),
+        ..Default::default()
     })
 }
 

--- a/src/poller/opencode.rs
+++ b/src/poller/opencode.rs
@@ -84,6 +84,13 @@ fn poll_dashboard(credentials: &DashboardCredentials) -> Result<UsageData, PollE
         session,
         weekly,
         weekly_label,
+        // The monthly window is kept available to themes alongside the
+        // auto-selected `weekly` slot (which prefers the more constrained
+        // of the two windows, as before).
+        monthly: usage
+            .monthly
+            .as_ref()
+            .map(|window| section_from_window(window, now)),
     })
 }
 

--- a/src/poller/tests.rs
+++ b/src/poller/tests.rs
@@ -8,6 +8,7 @@ fn usage_with_session_percent(percentage: f64) -> UsageData {
         },
         weekly: UsageSection::default(),
         weekly_label: None,
+        ..Default::default()
     }
 }
 

--- a/src/studio_app/tests.rs
+++ b/src/studio_app/tests.rs
@@ -268,6 +268,7 @@ fn studio_preview_uses_cached_poll_failure_state_instead_of_stale_values() {
             },
             weekly: Default::default(),
             weekly_label: None,
+            ..Default::default()
         },
     )]));
     app.usage_poll_ok = false;

--- a/src/theme_engine.rs
+++ b/src/theme_engine.rs
@@ -1321,6 +1321,22 @@ impl DataContext {
         self.insert(&format!("{name}.session.remaining"), 100.0 - session);
         self.insert(&format!("{name}.weekly.percentage"), weekly);
         self.insert(&format!("{name}.weekly.remaining"), 100.0 - weekly);
+        let monthly = usage.and_then(|usage| usage.monthly.as_ref());
+        if let Some(monthly) = monthly {
+            self.insert_string(&format!("{name}.monthly.label"), "30d");
+            self.insert(&format!("{name}.monthly.percentage"), monthly.percentage);
+            self.insert(
+                &format!("{name}.monthly.remaining"),
+                100.0 - monthly.percentage,
+            );
+        } else {
+            self.insert(&format!("{name}.monthly.percentage"), 0.0);
+            self.insert(&format!("{name}.monthly.remaining"), 100.0);
+        }
+        self.insert(
+            &format!("{name}.monthly.available"),
+            monthly.is_some() as u8 as f64,
+        );
         self.insert(&format!("{name}.available"), usage.is_some() as u8 as f64);
         let reset_value = |reset: Option<std::time::SystemTime>| {
             let unix = reset
@@ -1337,9 +1353,12 @@ impl DataContext {
             reset_value(usage.and_then(|value| value.session.resets_at));
         let (weekly_unix, weekly_seconds) =
             reset_value(usage.and_then(|value| value.weekly.resets_at));
+        let (monthly_unix, monthly_seconds) =
+            reset_value(monthly.and_then(|value| value.resets_at));
         for (window, unix, seconds) in [
             ("session", session_unix, session_seconds),
             ("weekly", weekly_unix, weekly_seconds),
+            ("monthly", monthly_unix, monthly_seconds),
         ] {
             self.insert(&format!("{name}.{window}.reset.unix"), unix);
             self.insert(&format!("{name}.{window}.reset.seconds"), seconds);

--- a/src/theme_engine/tests.rs
+++ b/src/theme_engine/tests.rs
@@ -294,6 +294,7 @@ fn usage_lines_handle_loading_errors_missing_resets_and_language() {
             },
             weekly: crate::models::UsageSection::default(),
             weekly_label: None,
+            ..Default::default()
         },
     )]);
     let ready = DataContext::from_usage_with_runtime(
@@ -463,6 +464,7 @@ fn reset_stats_and_duration_formats_are_available_to_every_provider() {
             },
             weekly: crate::models::UsageSection::default(),
             weekly_label: None,
+            ..Default::default()
         },
     )]);
     let context = DataContext::from_usage(Some(&usage), &Canvas::default());
@@ -486,6 +488,47 @@ fn provider_specific_long_window_labels_are_available_to_templates() {
     let context = DataContext::from_usage(Some(&usage), &Canvas::default());
     assert_eq!(format_template("{opencode.weekly.label}", &context), "30d");
     assert_eq!(format_template("{claude.weekly.label}", &context), "7d");
+}
+
+#[test]
+fn opencode_monthly_window_is_available_to_templates_when_present() {
+    let reset = std::time::SystemTime::now() + std::time::Duration::from_secs(1_713_621);
+    let usage = crate::models::AppUsageData::from_iter([(
+        ProviderId::OpenCode,
+        crate::models::UsageData {
+            weekly_label: Some("30d".into()),
+            monthly: Some(crate::models::UsageSection {
+                percentage: 43.0,
+                resets_at: Some(reset),
+            }),
+            ..Default::default()
+        },
+    )]);
+    let context = DataContext::from_usage(Some(&usage), &Canvas::default());
+    assert_eq!(
+        evaluate("opencode.monthly.percentage", &context).unwrap(),
+        43.0
+    );
+    assert_eq!(
+        evaluate("opencode.monthly.remaining", &context).unwrap(),
+        57.0
+    );
+    assert_eq!(
+        evaluate("opencode.monthly.available", &context).unwrap(),
+        1.0
+    );
+    assert_eq!(format_template("{opencode.monthly.label}", &context), "30d");
+    assert_eq!(
+        format_template("{opencode.monthly.percentage:0.0}%", &context),
+        "43.0%"
+    );
+    assert!(evaluate("opencode.monthly.reset.seconds", &context).unwrap() > 1_713_600.0);
+    // Providers without a monthly window expose safe zeros and an availability flag.
+    assert_eq!(evaluate("claude.monthly.available", &context).unwrap(), 0.0);
+    assert_eq!(
+        evaluate("claude.monthly.percentage", &context).unwrap(),
+        0.0
+    );
 }
 
 #[test]

--- a/src/theme_engine/theme_expression.rs
+++ b/src/theme_engine/theme_expression.rs
@@ -319,7 +319,7 @@ pub(super) fn format_usage_line(base: &str, context: &DataContext) -> Option<Str
             provider,
             "active" | "claude" | "codex" | "antigravity" | "opencode" | "cursor"
         )
-        || !matches!(window, "session" | "weekly")
+        || !matches!(window, "session" | "weekly" | "monthly")
     {
         return None;
     }


### PR DESCRIPTION
The OpenCode poller already reads the monthly usage window from the dashboard, but it was only used to decide which long window to show in the widget. Whichever of the two (7d or 30d) is more constrained wins the weekly slot, and the monthly one was then thrown away. So there was no way to see the monthly limit on the widget even though the number was already being fetched.

This was for me the hard limit I was reaching when using the more expensive models, so I thought it could be beneficial to see the monthly as well.

This PR keeps that auto-selection unchanged, but also carries the monthly window through to the theme layer. Every provider now exposes monthly data inside themes:

- `{provider}.monthly.percentage`
- `{provider}.monthly.remaining`
- `{provider}.monthly.label` (usually `30d`)
- `{provider}.monthly.reset.seconds` / `.minutes` / `.hours` / `.days` / `.unix`
- `{provider}.monthly.available` (1 when monthly data is present, otherwise 0)

That makes it possible to add a monthly bar or readout to the widget in Theme Studio, next to the existing session and weekly ones. A render expression like `providers.opencode.enabled && opencode.monthly.available` keeps it hidden for users whose dashboard has no monthly window.

No visible change for existing themes, and old usage caches still load fine since the new field is optional in the cache format. I verified the full path end to end: the dashboard fetch, the cache round-trip, and the theme rendering (the monthly bar shows the live monthly percentage right next to the 7d bar).

Testing: `cargo test` (145 passed), `cargo fmt`, `cargo clippy` (no new warnings).

This is how it looks like:
<img width="566" height="46" alt="image" src="https://github.com/user-attachments/assets/523552dc-4072-4f94-8e82-cdff6af19d62" />