### PR TITLE
Read Claude usage when only the desktop app is installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ It works best if you want a simple "how close am I to the limit?" display that i
 
 If you use Claude Code through WSL, that is supported too. The monitor can read your Claude Code credentials from Windows or from your WSL environment.
 
+If you only ever run Claude Code inside the Claude desktop app, there is nothing else to install. The standalone CLI login writes `~/.claude/.credentials.json`, but the desktop app keeps its own encrypted token cache in `%APPDATA%\Claude\config.json`. The monitor reads that cache read-only, through the same Windows DPAPI and AES-GCM scheme the app itself uses, when no CLI credentials are available.
+
 ## Install
 
 Install the latest version from WinGet:
@@ -235,10 +237,11 @@ What it does **not** do:
 - It does not upload your project files
 - It opens Cursor's SQLite database read-only and never modifies it
 - It does not directly edit your Codex credentials file
+- It opens the Claude desktop app's token cache read-only and never modifies it
 
 Notes:
 
-- If your Claude Code token is expired, the app may ask the local Claude CLI to refresh it in the background
+- If your Claude Code token is expired, the app may ask the local Claude CLI to refresh it in the background. When the token came from the Claude desktop app, the desktop app refreshes it instead, so open the app and sign in again if it has lapsed.
 - If your Codex token is expired, the app may ask the local Codex CLI to refresh it in the background. The monitor does not write `auth.json` itself; any credential update is handled by the Codex CLI.
 - If your Antigravity token is expired, open Antigravity and sign in again. The monitor does not write Windows Credential Manager entries itself.
 - Portable installs can update themselves by downloading the latest release from this repository

--- a/src/poller.rs
+++ b/src/poller.rs
@@ -65,6 +65,7 @@ fn poll_with(
 
 mod antigravity;
 mod claude;
+mod claude_desktop;
 mod codex;
 mod cursor;
 mod opencode;

--- a/src/poller/claude.rs
+++ b/src/poller/claude.rs
@@ -1,10 +1,11 @@
 use std::os::windows::process::CommandExt;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use serde::Deserialize;
 
+use super::claude_desktop;
 use super::{
     build_agent, get_header_f64, get_header_i64, parse_iso8601, unix_to_system_time, PollError,
 };
@@ -34,10 +35,16 @@ struct Credentials {
     source: CredentialSource,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 enum CredentialSource {
     Windows(PathBuf),
-    Wsl { distro: String },
+    /// The Claude desktop app's own token cache, used when Claude Code has
+    /// only ever run inside the desktop app and no CLI login wrote
+    /// `~/.claude/.credentials.json`.
+    DesktopApp(PathBuf),
+    Wsl {
+        distro: String,
+    },
 }
 
 pub(super) fn poll_claude_code() -> Result<UsageData, PollError> {
@@ -244,6 +251,11 @@ fn refresh_or_fallback(mut credentials: Credentials) -> Result<Credentials, Poll
 fn cli_refresh_token(source: &CredentialSource) {
     match source {
         CredentialSource::Windows(_) => cli_refresh_windows_token(),
+        // The desktop app owns this token and refreshes it itself, so there is
+        // nothing to drive from here; re-reading the cache is the whole retry.
+        CredentialSource::DesktopApp(_) => {
+            diagnose::log("Claude desktop app refreshes its own token; re-reading the cache")
+        }
         CredentialSource::Wsl { distro } => cli_refresh_wsl_token(distro),
     }
 }
@@ -346,22 +358,35 @@ fn resolve_windows_claude_path() -> String {
         }
     }
 
+    if let Some(bundled) = bundled_desktop_claude_path() {
+        return bundled.to_string_lossy().into_owned();
+    }
+
     "claude.cmd".to_string()
 }
 
-fn read_first_credentials() -> Option<Credentials> {
-    read_windows_credentials().or_else(|| {
-        list_wsl_distros()
-            .into_iter()
-            .find_map(|distro| read_wsl_credentials(&distro))
-    })
+/// The desktop app ships its own Claude Code build under
+/// `%APPDATA%\Claude\claude-code\<version>\claude.exe`, which is the only
+/// Claude binary present when the standalone CLI was never installed.
+fn bundled_desktop_claude_path() -> Option<PathBuf> {
+    let versions = dirs::config_dir()?.join("Claude").join("claude-code");
+    let mut candidates: Vec<PathBuf> = std::fs::read_dir(versions)
+        .ok()?
+        .flatten()
+        .map(|entry| entry.path().join("claude.exe"))
+        .filter(|path| path.is_file())
+        .collect();
+    // Directory order is not version order; the newest install wins.
+    candidates.sort();
+    candidates.pop()
 }
 
-fn read_windows_credentials() -> Option<Credentials> {
-    let CredentialSource::Windows(path) = windows_credential_source()? else {
-        return None;
-    };
-    let content = match std::fs::read_to_string(&path) {
+fn read_first_credentials() -> Option<Credentials> {
+    credential_sources_in_order().find_map(|source| read_credentials_from_source(&source))
+}
+
+fn read_windows_credentials(path: &Path) -> Option<Credentials> {
+    let content = match std::fs::read_to_string(path) {
         Ok(content) => content,
         Err(error) => {
             if diagnose::is_enabled() {
@@ -373,15 +398,23 @@ fn read_windows_credentials() -> Option<Credentials> {
             return None;
         }
     };
-    parse_credentials(&content, CredentialSource::Windows(path))
+    parse_credentials(&content, CredentialSource::Windows(path.to_path_buf()))
+}
+
+fn read_desktop_app_credentials(path: &Path) -> Option<Credentials> {
+    let token = claude_desktop::read_token(path)?;
+    diagnose::log("using the Claude desktop app token cache");
+    Some(Credentials {
+        access_token: token.access_token,
+        expires_at: token.expires_at,
+        source: CredentialSource::DesktopApp(path.to_path_buf()),
+    })
 }
 
 fn read_credentials_from_source(source: &CredentialSource) -> Option<Credentials> {
     match source {
-        CredentialSource::Windows(path) => {
-            let content = std::fs::read_to_string(path).ok()?;
-            parse_credentials(&content, source.clone())
-        }
+        CredentialSource::Windows(path) => read_windows_credentials(path),
+        CredentialSource::DesktopApp(path) => read_desktop_app_credentials(path),
         CredentialSource::Wsl { distro } => read_wsl_credentials(distro),
     }
 }
@@ -429,33 +462,27 @@ fn parse_credentials(content: &str, source: CredentialSource) -> Option<Credenti
 }
 
 fn read_next_credentials_after(source: &CredentialSource) -> Option<Credentials> {
-    let distros = list_wsl_distros();
-    let candidates: Box<dyn Iterator<Item = String>> = match source {
-        CredentialSource::Windows(_) => Box::new(distros.into_iter()),
-        CredentialSource::Wsl { distro } => Box::new(
-            distros
-                .into_iter()
-                .skip_while({
-                    let distro = distro.clone();
-                    move |candidate| candidate != &distro
-                })
-                .skip(1),
-        ),
-    };
-    candidates
-        .filter_map(|distro| read_wsl_credentials(&distro))
-        .next()
+    credential_sources_in_order()
+        .skip_while(|candidate| candidate != source)
+        .skip(1)
+        .find_map(|candidate| read_credentials_from_source(&candidate))
+}
+
+/// Credential sources, cheapest first. The WSL probe stays lazy so a machine
+/// that resolves a token locally never has to spawn `wsl.exe`.
+fn credential_sources_in_order() -> impl Iterator<Item = CredentialSource> {
+    windows_credential_source()
+        .into_iter()
+        .chain(desktop_app_credential_source())
+        .chain(
+            std::iter::once_with(list_wsl_distros)
+                .flatten()
+                .map(|distro| CredentialSource::Wsl { distro }),
+        )
 }
 
 fn all_known_credential_sources() -> Vec<CredentialSource> {
-    windows_credential_source()
-        .into_iter()
-        .chain(
-            list_wsl_distros()
-                .into_iter()
-                .map(|distro| CredentialSource::Wsl { distro }),
-        )
-        .collect()
+    credential_sources_in_order().collect()
 }
 
 fn windows_credential_source() -> Option<CredentialSource> {
@@ -464,9 +491,14 @@ fn windows_credential_source() -> Option<CredentialSource> {
     ))
 }
 
+fn desktop_app_credential_source() -> Option<CredentialSource> {
+    claude_desktop::config_path().map(CredentialSource::DesktopApp)
+}
+
 fn credential_watch_signature(source: &CredentialSource) -> Option<String> {
     match source {
         CredentialSource::Windows(path) => Some(windows_credential_watch_signature(path)),
+        CredentialSource::DesktopApp(path) => Some(claude_desktop::watch_signature(path)),
         CredentialSource::Wsl { distro } => wsl_credential_watch_signature(distro),
     }
 }

--- a/src/poller/claude_desktop.rs
+++ b/src/poller/claude_desktop.rs
@@ -1,0 +1,516 @@
+//! Reads the OAuth token that the Claude desktop app keeps for its bundled
+//! Claude Code build.
+//!
+//! Machines that only ever ran Claude Code through the desktop app have no
+//! `~/.claude/.credentials.json`, because that file is written by the
+//! standalone CLI login flow. The desktop app is an Electron application and
+//! stores its token cache with Chromium's OSCrypt scheme instead: an
+//! AES-256-GCM key sits DPAPI-wrapped in `Local State`, and each encrypted
+//! value is `"v10" || nonce || ciphertext || tag`.
+//!
+//! Everything here is read-only, runs as the signed-in user, and degrades to
+//! `None` whenever the layout is not what we expect.
+
+use std::ffi::c_void;
+use std::path::{Path, PathBuf};
+
+use crate::diagnose;
+
+const TOKEN_CACHE_KEY: &str = "oauth:tokenCache";
+const DPAPI_KEY_PREFIX: &[u8] = b"DPAPI";
+const OS_CRYPT_PREFIX: &[u8] = b"v10";
+const GCM_NONCE_LEN: usize = 12;
+const GCM_TAG_LEN: usize = 16;
+/// Desktop entries are keyed `"<install>:<user>:<base url>:<scopes>"`; the
+/// inference scope marks the token the usage endpoint accepts.
+const INFERENCE_SCOPE: &str = "user:inference";
+const BCRYPT_INIT_AUTH_MODE_INFO_VERSION: u32 = 1;
+
+pub(super) struct DesktopToken {
+    pub(super) access_token: String,
+    pub(super) expires_at: Option<i64>,
+}
+
+pub(super) fn config_path() -> Option<PathBuf> {
+    Some(dirs::config_dir()?.join("Claude").join("config.json"))
+}
+
+fn local_state_path(config_path: &Path) -> PathBuf {
+    config_path.with_file_name("Local State")
+}
+
+pub(super) fn read_token(config_path: &Path) -> Option<DesktopToken> {
+    let config = match std::fs::read_to_string(config_path) {
+        Ok(config) => config,
+        Err(error) => {
+            if diagnose::is_enabled() {
+                diagnose::log_error(
+                    &format!(
+                        "unable to read Claude desktop config at {}",
+                        config_path.display()
+                    ),
+                    error,
+                );
+            }
+            return None;
+        }
+    };
+
+    let cache = token_cache_value(&config)?;
+    let key = os_crypt_key(&local_state_path(config_path))?;
+    let plaintext = decrypt_os_crypt_value(&cache, &key)?;
+    let plaintext = String::from_utf8(plaintext).ok()?;
+    let token = select_token(&plaintext);
+    if token.is_none() {
+        diagnose::log("Claude desktop token cache held no usable inference token");
+    }
+    token
+}
+
+/// Signature over the encrypted cache rather than the file's mtime: the
+/// desktop app rewrites `config.json` for unrelated state such as window
+/// placement, and that must not read as a credential change.
+pub(super) fn watch_signature(config_path: &Path) -> String {
+    let key = format!("desktop:{}", config_path.display());
+    match std::fs::read_to_string(config_path)
+        .ok()
+        .and_then(|config| token_cache_value(&config))
+    {
+        Some(cache) => format!("{key}|present|{}", fnv1a(cache.as_bytes())),
+        None => format!("{key}|missing"),
+    }
+}
+
+fn token_cache_value(config: &str) -> Option<String> {
+    let json: serde_json::Value = serde_json::from_str(config).ok()?;
+    Some(json.get(TOKEN_CACHE_KEY)?.as_str()?.to_string())
+}
+
+/// Picks the freshest entry that carries the inference scope, falling back to
+/// the freshest entry of any scope so a future key layout still resolves.
+fn select_token(plaintext: &str) -> Option<DesktopToken> {
+    let json: serde_json::Value = serde_json::from_str(plaintext).ok()?;
+    let entries = json.as_object()?;
+
+    let mut best: Option<(bool, i64, DesktopToken)> = None;
+    for (key, entry) in entries {
+        let Some(access_token) = entry.get("token").and_then(|value| value.as_str()) else {
+            continue;
+        };
+        if access_token.is_empty() {
+            continue;
+        }
+        let expires_at = entry.get("expiresAt").and_then(|value| value.as_i64());
+        let rank = (
+            key.contains(INFERENCE_SCOPE),
+            expires_at.unwrap_or(i64::MIN),
+        );
+        if best
+            .as_ref()
+            .is_some_and(|(scoped, expiry, _)| (*scoped, *expiry) >= rank)
+        {
+            continue;
+        }
+        best = Some((
+            rank.0,
+            rank.1,
+            DesktopToken {
+                access_token: access_token.to_string(),
+                expires_at,
+            },
+        ));
+    }
+
+    best.map(|(_, _, token)| token)
+}
+
+fn os_crypt_key(local_state_path: &Path) -> Option<Vec<u8>> {
+    let local_state = std::fs::read_to_string(local_state_path).ok()?;
+    let json: serde_json::Value = serde_json::from_str(&local_state).ok()?;
+    let encoded = json.get("os_crypt")?.get("encrypted_key")?.as_str()?;
+    let wrapped = base64_decode(encoded)?;
+    let wrapped = wrapped.strip_prefix(DPAPI_KEY_PREFIX)?;
+    dpapi_unprotect(wrapped)
+}
+
+fn decrypt_os_crypt_value(value: &str, key: &[u8]) -> Option<Vec<u8>> {
+    let blob = base64_decode(value)?;
+    let body = blob.strip_prefix(OS_CRYPT_PREFIX)?;
+    if body.len() < GCM_NONCE_LEN + GCM_TAG_LEN {
+        return None;
+    }
+    let (nonce, rest) = body.split_at(GCM_NONCE_LEN);
+    let (ciphertext, tag) = rest.split_at(rest.len() - GCM_TAG_LEN);
+    aes_gcm_decrypt(key, nonce, ciphertext, tag)
+}
+
+fn base64_decode(input: &str) -> Option<Vec<u8>> {
+    let input = input.trim_end_matches('=');
+    if input.len() % 4 == 1 {
+        return None;
+    }
+    let mut output = Vec::with_capacity(input.len() * 3 / 4);
+    let mut buffer = 0u32;
+    let mut bits = 0u32;
+    for byte in input.bytes() {
+        let value = match byte {
+            b'A'..=b'Z' => byte - b'A',
+            b'a'..=b'z' => byte - b'a' + 26,
+            b'0'..=b'9' => byte - b'0' + 52,
+            b'+' => 62,
+            b'/' => 63,
+            _ => return None,
+        } as u32;
+        buffer = (buffer << 6) | value;
+        bits += 6;
+        if bits >= 8 {
+            bits -= 8;
+            output.push(((buffer >> bits) & 0xff) as u8);
+        }
+    }
+    let padding_mask = (1u32 << bits).saturating_sub(1);
+    (buffer & padding_mask == 0).then_some(output)
+}
+
+fn fnv1a(bytes: &[u8]) -> u64 {
+    let mut hash = 0xcbf2_9ce4_8422_2325u64;
+    for byte in bytes {
+        hash ^= *byte as u64;
+        hash = hash.wrapping_mul(0x100_0000_01b3);
+    }
+    hash
+}
+
+fn wide(value: &str) -> Vec<u16> {
+    value.encode_utf16().chain(std::iter::once(0)).collect()
+}
+
+#[repr(C)]
+struct CryptIntegerBlob {
+    cb_data: u32,
+    pb_data: *mut u8,
+}
+
+#[repr(C)]
+struct AuthenticatedCipherModeInfo {
+    cb_size: u32,
+    dw_info_version: u32,
+    pb_nonce: *mut u8,
+    cb_nonce: u32,
+    pb_auth_data: *mut u8,
+    cb_auth_data: u32,
+    pb_tag: *mut u8,
+    cb_tag: u32,
+    pb_mac_context: *mut u8,
+    cb_mac_context: u32,
+    cb_aad: u32,
+    cb_data: u64,
+    dw_flags: u32,
+}
+
+#[link(name = "crypt32")]
+extern "system" {
+    fn CryptUnprotectData(
+        data_in: *const CryptIntegerBlob,
+        data_description: *mut *mut u16,
+        optional_entropy: *const CryptIntegerBlob,
+        reserved: *mut c_void,
+        prompt_struct: *mut c_void,
+        flags: u32,
+        data_out: *mut CryptIntegerBlob,
+    ) -> i32;
+}
+
+extern "system" {
+    fn LocalFree(mem: *mut c_void) -> *mut c_void;
+}
+
+#[link(name = "bcrypt")]
+extern "system" {
+    fn BCryptOpenAlgorithmProvider(
+        algorithm: *mut *mut c_void,
+        id: *const u16,
+        implementation: *const u16,
+        flags: u32,
+    ) -> i32;
+    fn BCryptCloseAlgorithmProvider(algorithm: *mut c_void, flags: u32) -> i32;
+    fn BCryptGetProperty(
+        object: *mut c_void,
+        property: *const u16,
+        output: *mut u8,
+        output_len: u32,
+        result: *mut u32,
+        flags: u32,
+    ) -> i32;
+    fn BCryptSetProperty(
+        object: *mut c_void,
+        property: *const u16,
+        input: *const u8,
+        input_len: u32,
+        flags: u32,
+    ) -> i32;
+    fn BCryptGenerateSymmetricKey(
+        algorithm: *mut c_void,
+        key: *mut *mut c_void,
+        key_object: *mut u8,
+        key_object_len: u32,
+        secret: *const u8,
+        secret_len: u32,
+        flags: u32,
+    ) -> i32;
+    fn BCryptDestroyKey(key: *mut c_void) -> i32;
+    fn BCryptDecrypt(
+        key: *mut c_void,
+        input: *const u8,
+        input_len: u32,
+        padding_info: *const c_void,
+        iv: *mut u8,
+        iv_len: u32,
+        output: *mut u8,
+        output_len: u32,
+        result: *mut u32,
+        flags: u32,
+    ) -> i32;
+}
+
+fn dpapi_unprotect(data: &[u8]) -> Option<Vec<u8>> {
+    let input = CryptIntegerBlob {
+        cb_data: u32::try_from(data.len()).ok()?,
+        pb_data: data.as_ptr() as *mut u8,
+    };
+    let mut output = CryptIntegerBlob {
+        cb_data: 0,
+        pb_data: std::ptr::null_mut(),
+    };
+
+    let ok = unsafe {
+        CryptUnprotectData(
+            &input,
+            std::ptr::null_mut(),
+            std::ptr::null(),
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+            0,
+            &mut output,
+        )
+    };
+
+    if ok == 0 || output.pb_data.is_null() {
+        diagnose::log("unable to unwrap the Claude desktop OSCrypt key with DPAPI");
+        return None;
+    }
+
+    Some(unsafe {
+        let key = std::slice::from_raw_parts(output.pb_data, output.cb_data as usize).to_vec();
+        LocalFree(output.pb_data as *mut c_void);
+        key
+    })
+}
+
+fn aes_gcm_decrypt(key: &[u8], nonce: &[u8], ciphertext: &[u8], tag: &[u8]) -> Option<Vec<u8>> {
+    let algorithm_id = wide("AES");
+    let mut algorithm: *mut c_void = std::ptr::null_mut();
+    if unsafe {
+        BCryptOpenAlgorithmProvider(&mut algorithm, algorithm_id.as_ptr(), std::ptr::null(), 0)
+    } != 0
+    {
+        diagnose::log("unable to open the AES provider for the Claude desktop token cache");
+        return None;
+    }
+
+    let plaintext = with_gcm_key(algorithm, key, |key_handle| {
+        decrypt_with_key(key_handle, nonce, ciphertext, tag)
+    });
+
+    unsafe { BCryptCloseAlgorithmProvider(algorithm, 0) };
+    plaintext
+}
+
+fn with_gcm_key(
+    algorithm: *mut c_void,
+    key: &[u8],
+    decrypt: impl FnOnce(*mut c_void) -> Option<Vec<u8>>,
+) -> Option<Vec<u8>> {
+    let chaining_property = wide("ChainingMode");
+    let chaining_gcm = wide("ChainingModeGCM");
+    if unsafe {
+        BCryptSetProperty(
+            algorithm,
+            chaining_property.as_ptr(),
+            chaining_gcm.as_ptr() as *const u8,
+            u32::try_from(std::mem::size_of_val(chaining_gcm.as_slice())).ok()?,
+            0,
+        )
+    } != 0
+    {
+        diagnose::log("unable to select GCM chaining for the Claude desktop token cache");
+        return None;
+    }
+
+    let object_length_property = wide("ObjectLength");
+    let mut object_length = 0u32;
+    let mut written = 0u32;
+    if unsafe {
+        BCryptGetProperty(
+            algorithm,
+            object_length_property.as_ptr(),
+            &mut object_length as *mut u32 as *mut u8,
+            u32::try_from(std::mem::size_of::<u32>()).ok()?,
+            &mut written,
+            0,
+        )
+    } != 0
+    {
+        return None;
+    }
+
+    // The key object buffer must outlive the key handle it backs.
+    let mut key_object = vec![0u8; object_length as usize];
+    let mut key_handle: *mut c_void = std::ptr::null_mut();
+    if unsafe {
+        BCryptGenerateSymmetricKey(
+            algorithm,
+            &mut key_handle,
+            key_object.as_mut_ptr(),
+            object_length,
+            key.as_ptr(),
+            u32::try_from(key.len()).ok()?,
+            0,
+        )
+    } != 0
+    {
+        diagnose::log("unable to import the Claude desktop OSCrypt key");
+        return None;
+    }
+
+    let plaintext = decrypt(key_handle);
+    unsafe { BCryptDestroyKey(key_handle) };
+    drop(key_object);
+    plaintext
+}
+
+fn decrypt_with_key(
+    key_handle: *mut c_void,
+    nonce: &[u8],
+    ciphertext: &[u8],
+    tag: &[u8],
+) -> Option<Vec<u8>> {
+    let mut nonce = nonce.to_vec();
+    let mut tag = tag.to_vec();
+    let mode_info = AuthenticatedCipherModeInfo {
+        cb_size: u32::try_from(std::mem::size_of::<AuthenticatedCipherModeInfo>()).ok()?,
+        dw_info_version: BCRYPT_INIT_AUTH_MODE_INFO_VERSION,
+        pb_nonce: nonce.as_mut_ptr(),
+        cb_nonce: u32::try_from(nonce.len()).ok()?,
+        pb_auth_data: std::ptr::null_mut(),
+        cb_auth_data: 0,
+        pb_tag: tag.as_mut_ptr(),
+        cb_tag: u32::try_from(tag.len()).ok()?,
+        pb_mac_context: std::ptr::null_mut(),
+        cb_mac_context: 0,
+        cb_aad: 0,
+        cb_data: 0,
+        dw_flags: 0,
+    };
+
+    let mut plaintext = vec![0u8; ciphertext.len()];
+    let mut written = 0u32;
+    let status = unsafe {
+        BCryptDecrypt(
+            key_handle,
+            ciphertext.as_ptr(),
+            u32::try_from(ciphertext.len()).ok()?,
+            &mode_info as *const AuthenticatedCipherModeInfo as *const c_void,
+            std::ptr::null_mut(),
+            0,
+            plaintext.as_mut_ptr(),
+            u32::try_from(plaintext.len()).ok()?,
+            &mut written,
+            0,
+        )
+    };
+
+    if status != 0 {
+        diagnose::log("Claude desktop token cache failed AES-GCM authentication");
+        return None;
+    }
+
+    plaintext.truncate(written as usize);
+    Some(plaintext)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn selects_the_freshest_inference_scoped_token() {
+        let plaintext = r#"{
+            "install:user:https://api.anthropic.com:user:profile": {
+                "token": "profile-only",
+                "expiresAt": 9000000000000
+            },
+            "install:user:https://api.anthropic.com:user:inference user:profile": {
+                "token": "current",
+                "expiresAt": 1818644595762
+            },
+            "install:old:https://api.anthropic.com:user:inference": {
+                "token": "stale",
+                "expiresAt": 1518644595762
+            }
+        }"#;
+
+        let token = select_token(plaintext).expect("an inference token should be selected");
+        assert_eq!(token.access_token, "current");
+        assert_eq!(token.expires_at, Some(1818644595762));
+    }
+
+    #[test]
+    fn ignores_entries_without_a_usable_token() {
+        assert!(select_token(r#"{"install:user:scope": {"expiresAt": 1}}"#).is_none());
+        assert!(select_token(r#"{"install:user:scope": {"token": ""}}"#).is_none());
+        assert!(select_token("not json").is_none());
+    }
+
+    #[test]
+    fn reads_the_token_cache_out_of_a_desktop_config() {
+        let config = r#"{"locale": "en-US", "oauth:tokenCache": "djEwYWJj"}"#;
+        assert_eq!(token_cache_value(config).as_deref(), Some("djEwYWJj"));
+        assert!(token_cache_value(r#"{"locale": "en-US"}"#).is_none());
+    }
+
+    #[test]
+    fn rejects_blobs_that_are_not_os_crypt_v10() {
+        // Valid base64, but the version prefix is not "v10".
+        assert!(decrypt_os_crypt_value("bm90LXYxMC1kYXRh", &[0u8; 32]).is_none());
+        // Right prefix, too short to hold a nonce and a tag.
+        assert!(decrypt_os_crypt_value("djEwc2hvcnQ", &[0u8; 32]).is_none());
+        assert!(decrypt_os_crypt_value("!!!", &[0u8; 32]).is_none());
+    }
+
+    #[test]
+    fn decodes_standard_base64_with_and_without_padding() {
+        assert_eq!(base64_decode("djEw").unwrap(), b"v10");
+        assert_eq!(base64_decode("YWJjZA==").unwrap(), b"abcd");
+        assert!(base64_decode("a").is_none());
+        assert!(base64_decode("a-b_").is_none());
+    }
+
+    /// Ignored by default: this one proves the real DPAPI + AES-GCM path
+    /// against whatever the Claude desktop app has on the current machine.
+    /// Run it with `cargo test -- --ignored` while signed in to the app.
+    #[test]
+    #[ignore = "requires a signed-in Claude desktop app on this machine"]
+    fn reads_a_token_from_the_installed_desktop_app() {
+        let path = config_path().expect("a roaming config directory");
+        let token = read_token(&path).expect("the desktop app should expose a token");
+        assert!(token.access_token.starts_with("sk-ant-"));
+        assert!(token.expires_at.unwrap_or_default() > 0);
+    }
+
+    #[test]
+    fn watch_signature_reports_missing_config() {
+        let signature = watch_signature(Path::new("C:/nonexistent/Claude/config.json"));
+        assert!(signature.ends_with("|missing"), "{signature}");
+    }
+}


### PR DESCRIPTION
## Problem

The Claude credential chain resolves exactly two things: `~/.claude/.credentials.json` and the WSL copy of the same file. Both are written by the **standalone CLI login flow**.

Claude Code also ships inside the Claude desktop app, and that path never writes either file — the app holds its own OAuth token and hands it to the bundled Claude Code build in-process. So on a machine where Claude Code has only ever been used through the desktop app, `read_first_credentials()` returns `None`, the poll ends at `PollError::NoCredentials`, and the widget sits empty even though the user is signed in and actively burning quota.

The README already promises "Claude Code (CLI or App) installed and authenticated", so this closes the gap between that promise and the credential lookup.

There is a second, sneakier version of the same bug that this also fixes. If a user once had the CLI and later moved to the desktop app, `~/.claude/.credentials.json` is left behind frozen at whatever it last held. It expires, `cli_refresh_windows_token()` cannot repair it (the desktop app never rewrites that file, and the stale copy may have an empty `refreshToken`), and the monitor gives up rather than looking anywhere else. That is how I found this — my own file had been expired for 23 days while the app worked fine.

Related to #72, which reports the poor failure mode when a token cannot be renewed; this removes one of the causes.

## What this does

Adds the desktop app's token cache as a credential source, ordered **between** the Windows file and the WSL probe, so it is used both when no CLI login exists and when the CLI file has gone stale and unrefreshable.

The desktop app is Electron and stores the cache in `%APPDATA%\Claude\config.json` under `oauth:tokenCache`, encrypted with Chromium's OSCrypt scheme:

- an AES-256-GCM key sits DPAPI-wrapped in `Local State` under `os_crypt.encrypted_key`, behind a `DPAPI` prefix
- the value itself is `"v10" || nonce(12) || ciphertext || tag(16)`
- the plaintext is a map keyed `"<install>:<user>:<base url>:<scopes>"`, and the entry carrying `user:inference` is the one `/api/oauth/usage` accepts

New module `src/poller/claude_desktop.rs` does that decryption and selection. It picks the freshest inference-scoped entry, falling back to the freshest entry of any scope so a future key layout still resolves.

Two smaller pieces come with it:

- `resolve_windows_claude_path()` now falls back to the desktop app's bundled `claude.exe` under `%APPDATA%\Claude\claude-code\<version>\`, so the existing refresh path has a binary to call on machines with no CLI on `PATH`.
- The source list became one lazy ordered iterator shared by `read_first_credentials`, `read_next_credentials_after`, and `all_known_credential_sources`, replacing three separate spellings of the same ordering. It stays lazy, so a machine that resolves a local token still never spawns `wsl.exe`.

## Notes for review

**Security posture.** The module is read-only, decrypts with same-user DPAPI plus CNG on the machine that owns the credential, adds no dependencies, and returns `None` at every step where the layout is not what it expects. It touches the user's own token for the tool's stated purpose, the same as the existing `.credentials.json` read. Nothing is written back.

**Refresh.** `cli_refresh_token` is deliberately a no-op for this source: the desktop app owns and renews this token, so re-reading the cache *is* the retry. If it is genuinely expired the chain moves on to the next source rather than spawning a CLI that cannot help.

**Watch signature.** It hashes the encrypted cache string rather than the file's mtime, because the desktop app rewrites `config.json` for unrelated state such as window position, and that must not read as a credential change.

**FFI.** Raw `extern "system"` declarations with explicit `#[link]`, matching the existing `CredReadW` style in `antigravity.rs`, rather than pulling in a crypto crate.

## Testing

- `cargo build --release`, `cargo fmt --check`, and `cargo clippy --all-targets` are clean (the one remaining clippy warning, a `.fold` in `theme_storage.rs`, is pre-existing and untouched).
- `cargo test` — 162 pass.
- 6 new unit tests cover token selection and ranking, entries without a usable token, cache extraction, non-`v10` and truncated blob rejection, standard base64 with and without padding, and the missing-config signature.
- One `#[ignore]`d test, `reads_a_token_from_the_installed_desktop_app`, exercises the real DPAPI and AES-GCM path against whatever the app has installed locally. Run it with `cargo test -- --ignored` while signed in to the desktop app. It asserts on shape only and never prints the token.
- Verified end-to-end on Windows 11 with the desktop app signed in and `~/.claude/.credentials.json` expired: the decrypted token is accepted by `/api/oauth/usage` and returns live figures.

Happy to adjust the source ordering if you would rather have the desktop cache tried before the CLI file, or to split the `resolve_windows_claude_path` fallback into its own PR.
