### PR TITLE
Track paid credits, and fix three things found underneath

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,7 @@ Notes:
 - If your Codex token is expired, the app may ask the local Codex CLI to refresh it in the background. The monitor does not write `auth.json` itself; any credential update is handled by the Codex CLI.
 - If your Antigravity token is expired, open Antigravity and sign in again. The monitor does not write Windows Credential Manager entries itself.
 - Portable installs can update themselves by downloading the latest release from this repository
+- If the Claude usage endpoint is rate limited or briefly unavailable, the app keeps showing your last known figures and retries with a backoff, rather than spending quota on a request just to read its rate limit headers
 - Proxies should be trusted because proxied usage requests include your OAuth bearer token inside the TLS connection
 
 ## How It Works

--- a/src/app_settings.rs
+++ b/src/app_settings.rs
@@ -9,7 +9,7 @@ use windows::Win32::Storage::FileSystem::{
     MoveFileExW, MOVEFILE_REPLACE_EXISTING, MOVEFILE_WRITE_THROUGH,
 };
 
-use crate::models::AppUsageData;
+use crate::models::{AppUsageData, CodexCreditsState};
 use crate::providers::{ProviderId, ProviderSet};
 
 pub const POLL_1_MIN_SECONDS: u32 = 60;
@@ -247,6 +247,18 @@ fn settings_json(settings: &SettingsFile) -> serde_json::Value {
         }
     }
     value
+}
+
+pub fn codex_credits_path() -> PathBuf {
+    app_data_directory().join("codex-credits.json")
+}
+
+pub fn load_codex_credits() -> Option<CodexCreditsState> {
+    read_json(&codex_credits_path())
+}
+
+pub fn save_codex_credits(state: &CodexCreditsState) -> Result<(), String> {
+    write_json_atomic(&codex_credits_path(), state)
 }
 
 pub fn load_usage_cache() -> Option<UsageCache> {

--- a/src/models.rs
+++ b/src/models.rs
@@ -12,12 +12,43 @@ pub struct UsageSection {
     pub resets_at: Option<SystemTime>,
 }
 
+/// Paid credits that carry a provider past its included allowance.
+///
+/// `None` on [`UsageData`] means the provider has nothing to show: credits are
+/// switched off, unavailable on the plan, or not yet in play because the
+/// included allowance still has room.
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+pub struct CreditsSection {
+    /// Share of the current allowance already consumed, 0 to 100.
+    pub percentage: f64,
+    /// What is left, in whole currency units.
+    pub remaining: f64,
+    /// What `percentage` is measured against, in whole currency units: a
+    /// plan's cap where there is one, otherwise the balance recorded at the
+    /// last top-up.
+    pub total: f64,
+}
+
 #[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
 pub struct UsageData {
     pub session: UsageSection,
     pub weekly: UsageSection,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub weekly_label: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub credits: Option<CreditsSection>,
+}
+
+/// Codex reports a credit balance with no ceiling, so the denominator has to
+/// be learned: any rise in the balance is a top-up, and the balance recorded
+/// at that moment becomes what the gauge measures against until the next one.
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+pub struct CodexCreditsState {
+    /// Balance seen at the previous poll, in raw credits.
+    pub balance: f64,
+    /// Balance recorded at the last observed top-up, in raw credits. Seeded
+    /// from the first balance we ever see.
+    pub baseline: f64,
 }
 
 #[derive(Clone, Debug, Default, PartialEq)]

--- a/src/models.rs
+++ b/src/models.rs
@@ -37,6 +37,10 @@ pub struct UsageData {
     pub weekly_label: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub credits: Option<CreditsSection>,
+    /// True when this reading was carried over from an earlier poll because
+    /// the provider failed this cycle. The figures are real, just not current.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub stale: bool,
 }
 
 /// Codex reports a credit balance with no ceiling, so the denominator has to

--- a/src/poller.rs
+++ b/src/poller.rs
@@ -30,6 +30,31 @@ pub fn poll(enabled_providers: ProviderSet) -> Result<AppUsageData, PollFailure>
     poll_with(enabled_providers, poll_provider)
 }
 
+/// Keep the previous reading for any enabled provider that failed this cycle.
+///
+/// A poll succeeds as long as one provider answers, so without this a single
+/// provider's outage blanks its row on every refresh while the others carry
+/// on updating. The carried figures are marked stale rather than passed off as
+/// current.
+pub fn carry_forward_failures(
+    fresh: AppUsageData,
+    previous: &AppUsageData,
+    enabled: ProviderSet,
+) -> AppUsageData {
+    let mut merged = fresh;
+    for provider in enabled.iter() {
+        if merged.get(provider).is_some() {
+            continue;
+        }
+        if let Some(last) = previous.get(provider) {
+            let mut carried = last.clone();
+            carried.stale = true;
+            merged.insert(provider, carried);
+        }
+    }
+    merged
+}
+
 fn poll_with(
     enabled_providers: ProviderSet,
     mut poll_provider: impl FnMut(ProviderId) -> Result<UsageData, PollError>,

--- a/src/poller/antigravity.rs
+++ b/src/poller/antigravity.rs
@@ -171,6 +171,7 @@ pub(super) fn fetch_antigravity_usage_from_endpoint(
         session,
         weekly,
         weekly_label: None,
+        credits: None,
     })
 }
 

--- a/src/poller/antigravity.rs
+++ b/src/poller/antigravity.rs
@@ -172,6 +172,7 @@ pub(super) fn fetch_antigravity_usage_from_endpoint(
         weekly,
         weekly_label: None,
         credits: None,
+        stale: false,
     })
 }
 

--- a/src/poller/claude.rs
+++ b/src/poller/claude.rs
@@ -10,7 +10,7 @@ use super::{
     build_agent, get_header_f64, get_header_i64, parse_iso8601, unix_to_system_time, PollError,
 };
 use crate::diagnose;
-use crate::models::UsageData;
+use crate::models::{CreditsSection, UsageData};
 
 const USAGE_URL: &str = "https://api.anthropic.com/api/oauth/usage";
 const MESSAGES_URL: &str = "https://api.anthropic.com/v1/messages";
@@ -21,6 +21,30 @@ const CREATE_NO_WINDOW: u32 = 0x08000000;
 struct UsageResponse {
     five_hour: Option<UsageBucket>,
     seven_day: Option<UsageBucket>,
+    spend: Option<SpendResponse>,
+}
+
+/// Paid credits that carry the account past its plan limits. Amounts are
+/// minor units with their own exponent, so the currency is self-describing.
+#[derive(Deserialize)]
+struct SpendResponse {
+    #[serde(default)]
+    enabled: bool,
+    used: Option<SpendAmount>,
+    limit: Option<SpendAmount>,
+}
+
+#[derive(Deserialize)]
+struct SpendAmount {
+    amount_minor: f64,
+    #[serde(default)]
+    exponent: u32,
+}
+
+impl SpendAmount {
+    fn major(&self) -> f64 {
+        self.amount_minor / 10f64.powi(self.exponent as i32)
+    }
 }
 
 #[derive(Deserialize)]
@@ -98,13 +122,24 @@ pub(super) fn try_usage_endpoint(token: &str) -> Result<Option<UsageData>, PollE
         .call()
     {
         Ok(resp) => resp,
-        Err(ureq::Error::Status(code, _)) if code == 401 || code == 403 => {
-            diagnose::log(format!(
-                "usage endpoint returned auth error status {code}; re-login required"
-            ));
-            return Err(PollError::AuthRequired);
-        }
-        Err(_) => return Ok(None),
+        Err(error) => match classify_usage_failure(&error) {
+            UsageEndpointFailure::Auth => {
+                diagnose::log(format!(
+                    "usage endpoint returned an auth error ({error}); re-login required"
+                ));
+                return Err(PollError::AuthRequired);
+            }
+            UsageEndpointFailure::Transient => {
+                diagnose::log(format!("usage endpoint temporarily unavailable ({error})"));
+                return Err(PollError::RequestFailed);
+            }
+            UsageEndpointFailure::Unsupported => {
+                diagnose::log(format!(
+                    "usage endpoint unavailable for this account ({error}); trying the Messages API"
+                ));
+                return Ok(None);
+            }
+        },
     };
 
     let response: UsageResponse = match resp.into_json() {
@@ -123,7 +158,63 @@ pub(super) fn try_usage_endpoint(token: &str) -> Result<Option<UsageData>, PollE
         data.weekly.resets_at = parse_iso8601(bucket.resets_at.as_deref());
     }
 
+    data.credits = response
+        .spend
+        .as_ref()
+        .and_then(|spend| claude_credits(spend, &data));
+
     Ok(Some(data))
+}
+
+/// What a failed call to the usage endpoint actually tells us.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum UsageEndpointFailure {
+    /// The credentials were rejected.
+    Auth,
+    /// Rate limited, a server-side fault, or the network. Retrying later is
+    /// the right move. Asking the Messages API instead would spend real quota
+    /// on a request whose only purpose is to read headers, and during a rate
+    /// limit it would add to the load that caused it.
+    Transient,
+    /// The endpoint is not usable on this account, which is what the Messages
+    /// API fallback exists for.
+    Unsupported,
+}
+
+fn classify_usage_failure(error: &ureq::Error) -> UsageEndpointFailure {
+    match error {
+        ureq::Error::Status(401 | 403, _) => UsageEndpointFailure::Auth,
+        ureq::Error::Status(429, _) => UsageEndpointFailure::Transient,
+        ureq::Error::Status(code, _) if *code >= 500 => UsageEndpointFailure::Transient,
+        ureq::Error::Status(_, _) => UsageEndpointFailure::Unsupported,
+        ureq::Error::Transport(_) => UsageEndpointFailure::Transient,
+    }
+}
+
+/// Unlike Codex, the plan states its own ceiling, so the gauge needs no
+/// history: `used` is already the spend against the current cap, and a
+/// non-zero figure is the same "credits are in play" observation that the
+/// Codex balance gives by falling. Accounts with extra usage switched off
+/// report it disabled and get no gauge rather than an empty one.
+fn claude_credits(spend: &SpendResponse, data: &UsageData) -> Option<CreditsSection> {
+    let used = spend.used.as_ref()?.major();
+    let total = spend.limit.as_ref()?.major();
+    if !spend.enabled || !total.is_finite() || total <= 0.0 {
+        return None;
+    }
+
+    // Hold the ordinary windows until one of them is spent and credits have
+    // started covering the overflow.
+    let limit_reached = data.session.percentage >= 100.0 || data.weekly.percentage >= 100.0;
+    if !limit_reached || used <= 0.0 {
+        return None;
+    }
+
+    Some(CreditsSection {
+        percentage: ((used / total) * 100.0).clamp(0.0, 100.0),
+        remaining: (total - used).max(0.0),
+        total,
+    })
 }
 
 pub(super) fn fetch_usage_via_messages(token: &str) -> Result<UsageData, PollError> {
@@ -659,7 +750,7 @@ fn wait_for_refresh(child: &mut std::process::Child) {
 
 #[cfg(test)]
 mod tests {
-    use super::bundled_claude_version;
+    use super::*;
     use std::path::Path;
 
     #[test]
@@ -675,5 +766,129 @@ mod tests {
         let version = bundled_claude_version(Path::new("Claude/claude-code/current/claude.exe"));
 
         assert_eq!(version, None);
+    }
+
+    fn usage_from_json(json: &str) -> UsageData {
+        let response: UsageResponse =
+            serde_json::from_str(json).expect("the fixture should deserialize");
+        let mut data = UsageData::default();
+        if let Some(bucket) = &response.seven_day {
+            data.weekly.percentage = bucket.utilization;
+        }
+        if let Some(bucket) = &response.five_hour {
+            data.session.percentage = bucket.utilization;
+        }
+        data.credits = response
+            .spend
+            .as_ref()
+            .and_then(|spend| claude_credits(spend, &data));
+        data
+    }
+
+    fn status_error(code: u16) -> ureq::Error {
+        ureq::Error::Status(
+            code,
+            ureq::Response::new(code, "status", "").expect("response"),
+        )
+    }
+
+    #[test]
+    fn rate_limits_and_server_faults_do_not_trigger_the_messages_fallback() {
+        // Spending quota on a Messages request is the wrong answer to being
+        // rate limited, and it feeds the condition that caused it.
+        assert_eq!(
+            classify_usage_failure(&status_error(429)),
+            UsageEndpointFailure::Transient
+        );
+        assert_eq!(
+            classify_usage_failure(&status_error(500)),
+            UsageEndpointFailure::Transient
+        );
+        assert_eq!(
+            classify_usage_failure(&status_error(503)),
+            UsageEndpointFailure::Transient
+        );
+    }
+
+    #[test]
+    fn rejected_credentials_are_kept_separate_from_an_absent_endpoint() {
+        assert_eq!(
+            classify_usage_failure(&status_error(401)),
+            UsageEndpointFailure::Auth
+        );
+        assert_eq!(
+            classify_usage_failure(&status_error(403)),
+            UsageEndpointFailure::Auth
+        );
+        // A 404 is the case the Messages API fallback exists to cover.
+        assert_eq!(
+            classify_usage_failure(&status_error(404)),
+            UsageEndpointFailure::Unsupported
+        );
+    }
+
+    #[test]
+    fn spend_becomes_a_credit_gauge_against_the_plan_cap() {
+        // Shape taken from a live /api/oauth/usage response.
+        let data = usage_from_json(
+            r#"{
+                "seven_day": {"utilization": 100.0, "resets_at": null},
+                "spend": {
+                    "used": {"amount_minor": 1359, "currency": "USD", "exponent": 2},
+                    "limit": {"amount_minor": 5000, "currency": "USD", "exponent": 2},
+                    "percent": 27,
+                    "enabled": true
+                }
+            }"#,
+        );
+
+        let credits = data.credits.expect("enabled spend should expose a gauge");
+        assert!((credits.percentage - 27.18).abs() < 0.01, "{credits:?}");
+        assert!((credits.remaining - 36.41).abs() < 0.001, "{credits:?}");
+        assert_eq!(credits.total, 50.0);
+    }
+
+    #[test]
+    fn disabled_or_uncapped_spend_gets_no_gauge() {
+        assert!(usage_from_json(
+            r#"{"seven_day": {"utilization": 100.0},
+                "spend": {"used": {"amount_minor": 0, "exponent": 2},
+                          "limit": {"amount_minor": 5000, "exponent": 2}, "enabled": false}}"#
+        )
+        .credits
+        .is_none());
+
+        assert!(usage_from_json(
+            r#"{"seven_day": {"utilization": 100.0},
+                "spend": {"used": {"amount_minor": 10, "exponent": 2},
+                          "limit": {"amount_minor": 0, "exponent": 2}, "enabled": true}}"#
+        )
+        .credits
+        .is_none());
+
+        assert!(usage_from_json(r#"{"seven_day": {"utilization": 1.0}}"#)
+            .credits
+            .is_none());
+    }
+
+    #[test]
+    fn the_gauge_waits_for_a_spent_window_and_for_credits_to_be_in_play() {
+        let spend = r#""spend": {"used": {"amount_minor": 1359, "exponent": 2},
+                                 "limit": {"amount_minor": 5000, "exponent": 2}, "enabled": true}"#;
+
+        // Room left in both windows, so the bars stay on the ordinary limits.
+        let json = format!(r#"{{"five_hour": {{"utilization": 40.0}}, {spend}}}"#);
+        assert!(usage_from_json(&json).credits.is_none());
+
+        // A spent five-hour window is enough; it need not be the weekly one.
+        let json = format!(r#"{{"five_hour": {{"utilization": 100.0}}, {spend}}}"#);
+        assert!(usage_from_json(&json).credits.is_some());
+
+        // Spent window, but nothing charged to credits yet.
+        let json = r#"{"five_hour": {"utilization": 100.0},
+                       "spend": {"used": {"amount_minor": 0, "exponent": 2},
+                                 "limit": {"amount_minor": 5000, "exponent": 2},
+                                 "enabled": true}}"#;
+        assert!(usage_from_json(json).credits.is_none());
     }
 }

--- a/src/poller/codex.rs
+++ b/src/poller/codex.rs
@@ -6,8 +6,9 @@ use std::time::{Duration, UNIX_EPOCH};
 use serde::Deserialize;
 
 use super::{build_agent, unix_to_system_time, PollError};
+use crate::app_settings;
 use crate::diagnose;
-use crate::models::{UsageData, UsageSection};
+use crate::models::{CodexCreditsState, CreditsSection, UsageData, UsageSection};
 
 const CODEX_USAGE_URL: &str = "https://chatgpt.com/backend-api/wham/usage";
 const CREATE_NO_WINDOW: u32 = 0x08000000;
@@ -26,19 +27,48 @@ struct CodexTokenData {
 #[derive(Deserialize)]
 pub(super) struct CodexUsageResponse {
     rate_limit: Option<Option<Box<CodexRateLimitDetails>>>,
+    credits: Option<Option<Box<CodexCredits>>>,
 }
+
+#[derive(Deserialize)]
+struct CodexCredits {
+    #[serde(default)]
+    has_credits: bool,
+    #[serde(default)]
+    unlimited: bool,
+    #[serde(default)]
+    overage_limit_reached: bool,
+    /// Sent as a decimal string, in credits rather than currency.
+    balance: Option<String>,
+}
+
+/// Codex bills credits at 25 to the dollar. Only the displayed amount depends
+/// on this, never the gauge: a ratio of two credit figures is unit-free, so a
+/// change to this rate cannot make the bar wrong.
+const CODEX_CREDITS_PER_DOLLAR: f64 = 25.0;
 
 #[derive(Deserialize)]
 struct CodexRateLimitDetails {
     primary_window: Option<Option<Box<CodexRateLimitWindow>>>,
     secondary_window: Option<Option<Box<CodexRateLimitWindow>>>,
+    /// True once any window is spent, whichever one it was. Better than
+    /// reading a percentage back out of a window we mapped ourselves, and it
+    /// keeps working if the five-hour window is switched on again.
+    #[serde(default)]
+    limit_reached: bool,
 }
 
 #[derive(Deserialize)]
 pub(super) struct CodexRateLimitWindow {
     used_percent: f64,
     reset_at: i64,
+    limit_window_seconds: Option<i64>,
 }
+
+/// A window at or above this length is a weekly allowance rather than a
+/// session one. Codex currently sends 604800 for weekly and 18000 for the
+/// five-hour window, so anything from a day up is unambiguously weekly.
+const WEEKLY_WINDOW_THRESHOLD_SECONDS: i64 = 86_400;
 
 pub(super) fn poll_codex() -> Result<UsageData, PollError> {
     let creds = match read_codex_credentials() {
@@ -100,18 +130,102 @@ pub(super) fn fetch_codex_usage(
 }
 
 pub(super) fn codex_usage_from_response(response: CodexUsageResponse) -> Option<UsageData> {
+    let credits = response.credits.flatten();
     let details = *response.rate_limit.flatten()?;
     let mut data = UsageData::default();
 
-    if let Some(window) = details.primary_window.flatten() {
-        data.session = codex_section_from_window(&window);
+    // Assign by window length, not by slot. Codex has shipped the weekly
+    // allowance in `primary_window` with `secondary_window` empty while the
+    // five-hour window is switched off, so trusting the slot order puts a
+    // weekly figure in the session bar.
+    for window in [
+        details.primary_window.flatten(),
+        details.secondary_window.flatten(),
+    ]
+    .into_iter()
+    .flatten()
+    {
+        let section = codex_section_from_window(&window);
+        if window_is_weekly(&window) {
+            data.weekly = section;
+        } else {
+            data.session = section;
+        }
     }
 
-    if let Some(window) = details.secondary_window.flatten() {
-        data.weekly = codex_section_from_window(&window);
-    }
+    data.credits = credits.and_then(|credits| {
+        let previous = app_settings::load_codex_credits();
+        let (state, section) = codex_credits(previous, &credits, details.limit_reached);
+        if let Err(error) = app_settings::save_codex_credits(&state) {
+            diagnose::log(format!("unable to persist Codex credit baseline: {error}"));
+        }
+        section
+    });
 
     Some(data)
+}
+
+/// Tracks the balance across polls and turns it into a gauge.
+///
+/// The balance only ever falls as credits are spent, so any rise is a top-up
+/// and re-baselines the gauge. Tracking continues whether or not the gauge is
+/// shown, because a top-up that happens while the bar is hidden still has to
+/// move the baseline.
+fn codex_credits(
+    previous: Option<CodexCreditsState>,
+    credits: &CodexCredits,
+    limit_reached: bool,
+) -> (CodexCreditsState, Option<CreditsSection>) {
+    let balance = credits
+        .balance
+        .as_deref()
+        .and_then(|balance| balance.parse::<f64>().ok())
+        .filter(|balance| balance.is_finite() && *balance >= 0.0)
+        .unwrap_or_default();
+
+    let baseline = match previous {
+        // A rise can only come from a top-up. Seed from the first balance we
+        // see, which reads as untouched until the next top-up corrects it.
+        Some(previous) if balance <= previous.balance => previous.baseline.max(balance),
+        _ => balance,
+    };
+    let state = CodexCreditsState { balance, baseline };
+
+    // The bars stay on the ordinary windows until two things are true at once:
+    // an allowance is spent, and credits have actually started going down
+    // against the current top-up. The second half is an observation rather
+    // than an assumption about when a provider decides to bill credits, and it
+    // holds steady while idle, so the gauge does not flicker away on a poll
+    // that happens to see no change.
+    let in_use = balance < baseline;
+    let applicable =
+        credits.has_credits && !credits.unlimited && limit_reached && in_use && baseline > 0.0;
+    if !applicable {
+        return (state, None);
+    }
+
+    let percentage = if credits.overage_limit_reached {
+        100.0
+    } else {
+        (((baseline - balance) / baseline) * 100.0).clamp(0.0, 100.0)
+    };
+
+    (
+        state,
+        Some(CreditsSection {
+            percentage,
+            remaining: balance / CODEX_CREDITS_PER_DOLLAR,
+            total: baseline / CODEX_CREDITS_PER_DOLLAR,
+        }),
+    )
+}
+
+/// Falls back to treating an unlabelled window as a session window, which is
+/// what Codex sent before it started reporting `limit_window_seconds`.
+fn window_is_weekly(window: &CodexRateLimitWindow) -> bool {
+    window
+        .limit_window_seconds
+        .is_some_and(|seconds| seconds >= WEEKLY_WINDOW_THRESHOLD_SECONDS)
 }
 
 pub(super) fn codex_section_from_window(window: &CodexRateLimitWindow) -> UsageSection {
@@ -259,5 +373,176 @@ fn wait_for_refresh(child: &mut std::process::Child) {
             Ok(None) => std::thread::sleep(Duration::from_millis(500)),
             Err(_) => break,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn usage_from_json(json: &str) -> UsageData {
+        let response: CodexUsageResponse =
+            serde_json::from_str(json).expect("the fixture should deserialize");
+        codex_usage_from_response(response).expect("the fixture should carry rate limits")
+    }
+
+    fn credits(balance: &str, has_credits: bool) -> CodexCredits {
+        CodexCredits {
+            has_credits,
+            unlimited: false,
+            overage_limit_reached: false,
+            balance: Some(balance.into()),
+        }
+    }
+
+    #[test]
+    fn the_first_balance_seeds_the_baseline_and_reads_untouched() {
+        let (state, section) = codex_credits(None, &credits("1026.112935", true), true);
+
+        assert_eq!(state.baseline, 1026.112935);
+        // Nothing has been drawn against the seeded baseline yet, so the bars
+        // stay on the ordinary windows until a later poll sees it fall.
+        assert!(section.is_none());
+
+        // That later poll, with 25 credits to the dollar.
+        let previous = state;
+        let (_, section) = codex_credits(Some(previous), &credits("1016.190898", true), true);
+        let section = section.expect("a falling balance should expose the gauge");
+        assert!(
+            (section.remaining - 40.64763592).abs() < 1e-6,
+            "{section:?}"
+        );
+    }
+
+    #[test]
+    fn spending_against_a_baseline_fills_the_gauge() {
+        let previous = CodexCreditsState {
+            balance: 2500.0,
+            baseline: 2500.0,
+        };
+        let (state, section) = codex_credits(Some(previous), &credits("1250.0", true), true);
+
+        assert_eq!(state.baseline, 2500.0);
+        let section = section.expect("gauge");
+        assert_eq!(section.percentage, 50.0);
+        assert_eq!(section.remaining, 50.0);
+        assert_eq!(section.total, 100.0);
+    }
+
+    #[test]
+    fn a_rise_in_the_balance_is_a_reload_and_rebaselines() {
+        let previous = CodexCreditsState {
+            balance: 100.0,
+            baseline: 2500.0,
+        };
+        let (state, section) = codex_credits(Some(previous), &credits("2600.0", true), true);
+
+        assert_eq!(state.baseline, 2600.0);
+        // A fresh top-up has nothing spent against it, so the gauge stands
+        // down until credits start being drawn on again.
+        assert!(section.is_none());
+    }
+
+    #[test]
+    fn the_gauge_hides_while_an_allowance_remains() {
+        let previous = CodexCreditsState {
+            balance: 2000.0,
+            baseline: 2500.0,
+        };
+        let (state, section) = codex_credits(Some(previous), &credits("1000.0", true), false);
+
+        // Tracking continues while hidden so a reload still moves the baseline.
+        assert_eq!(state.balance, 1000.0);
+        assert_eq!(state.baseline, 2500.0);
+        assert!(section.is_none());
+    }
+
+    #[test]
+    fn accounts_without_credits_get_no_gauge() {
+        let (_, section) = codex_credits(None, &credits("0", false), true);
+        assert!(section.is_none());
+
+        let unlimited = CodexCredits {
+            unlimited: true,
+            ..credits("1000.0", true)
+        };
+        let (_, section) = codex_credits(None, &unlimited, true);
+        assert!(section.is_none());
+    }
+
+    #[test]
+    fn a_reached_overage_limit_pins_the_gauge_full() {
+        let previous = CodexCreditsState {
+            balance: 500.0,
+            baseline: 1000.0,
+        };
+        let reached = CodexCredits {
+            overage_limit_reached: true,
+            ..credits("500.0", true)
+        };
+        let (_, section) = codex_credits(Some(previous), &reached, true);
+
+        assert_eq!(section.expect("gauge").percentage, 100.0);
+    }
+
+    #[test]
+    fn a_lone_weekly_window_lands_in_the_weekly_bar() {
+        // Codex ships this shape while the five-hour window is switched off:
+        // the weekly allowance arrives in `primary_window`.
+        let data = usage_from_json(
+            r#"{
+                "rate_limit": {
+                    "primary_window": {
+                        "used_percent": 100,
+                        "limit_window_seconds": 604800,
+                        "reset_at": 1787198224
+                    },
+                    "secondary_window": null
+                }
+            }"#,
+        );
+
+        assert_eq!(data.weekly.percentage, 100.0);
+        assert_eq!(data.session.percentage, 0.0);
+        assert!(data.weekly.resets_at.is_some());
+        assert!(data.session.resets_at.is_none());
+    }
+
+    #[test]
+    fn windows_are_assigned_by_length_regardless_of_slot_order() {
+        let data = usage_from_json(
+            r#"{
+                "rate_limit": {
+                    "primary_window": {
+                        "used_percent": 80,
+                        "limit_window_seconds": 604800,
+                        "reset_at": 1787198224
+                    },
+                    "secondary_window": {
+                        "used_percent": 20,
+                        "limit_window_seconds": 18000,
+                        "reset_at": 1787100000
+                    }
+                }
+            }"#,
+        );
+
+        assert_eq!(data.weekly.percentage, 80.0);
+        assert_eq!(data.session.percentage, 20.0);
+    }
+
+    #[test]
+    fn an_unlabelled_window_stays_in_the_session_bar() {
+        let data = usage_from_json(
+            r#"{
+                "rate_limit": {
+                    "primary_window": {"used_percent": 42, "reset_at": 1787100000},
+                    "secondary_window": null
+                }
+            }"#,
+        );
+
+        assert_eq!(data.session.percentage, 42.0);
+        assert_eq!(data.weekly.percentage, 0.0);
     }
 }

--- a/src/poller/cursor.rs
+++ b/src/poller/cursor.rs
@@ -233,6 +233,7 @@ fn cursor_usage_from_summary(response: CursorUsageSummaryResponse) -> Option<Usa
         },
         weekly_label: Some("API".into()),
         credits: None,
+        stale: false,
     })
 }
 

--- a/src/poller/cursor.rs
+++ b/src/poller/cursor.rs
@@ -232,6 +232,7 @@ fn cursor_usage_from_summary(response: CursorUsageSummaryResponse) -> Option<Usa
             resets_at: reset,
         },
         weekly_label: Some("API".into()),
+        credits: None,
     })
 }
 

--- a/src/poller/opencode.rs
+++ b/src/poller/opencode.rs
@@ -85,6 +85,7 @@ fn poll_dashboard(credentials: &DashboardCredentials) -> Result<UsageData, PollE
         weekly,
         weekly_label,
         credits: None,
+        stale: false,
     })
 }
 

--- a/src/poller/opencode.rs
+++ b/src/poller/opencode.rs
@@ -84,6 +84,7 @@ fn poll_dashboard(credentials: &DashboardCredentials) -> Result<UsageData, PollE
         session,
         weekly,
         weekly_label,
+        credits: None,
     })
 }
 

--- a/src/poller/tests.rs
+++ b/src/poller/tests.rs
@@ -8,6 +8,7 @@ fn usage_with_session_percent(percentage: f64) -> UsageData {
         },
         weekly: UsageSection::default(),
         weekly_label: None,
+        credits: None,
     }
 }
 

--- a/src/poller/tests.rs
+++ b/src/poller/tests.rs
@@ -9,6 +9,7 @@ fn usage_with_session_percent(percentage: f64) -> UsageData {
         weekly: UsageSection::default(),
         weekly_label: None,
         credits: None,
+        stale: false,
     }
 }
 
@@ -203,4 +204,51 @@ fn antigravity_summary_prefers_gemini_group() {
     assert!((usage.session.percentage - 4.17425).abs() < 0.000001);
     assert!(usage.weekly.resets_at.is_some());
     assert!(usage.session.resets_at.is_some());
+}
+
+#[test]
+fn one_provider_failing_does_not_blank_its_row() {
+    let previous: AppUsageData = [
+        (ProviderId::Claude, usage_with_session_percent(21.0)),
+        (ProviderId::Codex, usage_with_session_percent(3.0)),
+    ]
+    .into_iter()
+    .collect();
+
+    // Only Codex answered this cycle.
+    let fresh: AppUsageData = [(ProviderId::Codex, usage_with_session_percent(9.0))]
+        .into_iter()
+        .collect();
+
+    let merged = carry_forward_failures(
+        fresh,
+        &previous,
+        ProviderSet::from_enabled([ProviderId::Claude, ProviderId::Codex]),
+    );
+
+    let claude = merged.get(ProviderId::Claude).expect("claude is kept");
+    assert_eq!(claude.session.percentage, 21.0);
+    assert!(claude.stale, "a carried reading must be marked stale");
+
+    let codex = merged.get(ProviderId::Codex).expect("codex refreshed");
+    assert_eq!(codex.session.percentage, 9.0);
+    assert!(!codex.stale, "a fresh reading must not be marked stale");
+}
+
+#[test]
+fn a_disabled_provider_is_not_resurrected() {
+    let previous: AppUsageData = [(ProviderId::Claude, usage_with_session_percent(21.0))]
+        .into_iter()
+        .collect();
+    let fresh: AppUsageData = [(ProviderId::Codex, usage_with_session_percent(9.0))]
+        .into_iter()
+        .collect();
+
+    let merged = carry_forward_failures(
+        fresh,
+        &previous,
+        ProviderSet::from_enabled([ProviderId::Codex]),
+    );
+
+    assert!(merged.get(ProviderId::Claude).is_none());
 }

--- a/src/studio_app/tests.rs
+++ b/src/studio_app/tests.rs
@@ -269,6 +269,7 @@ fn studio_preview_uses_cached_poll_failure_state_instead_of_stale_values() {
             weekly: Default::default(),
             weekly_label: None,
             credits: None,
+            stale: false,
         },
     )]));
     app.usage_poll_ok = false;

--- a/src/studio_app/tests.rs
+++ b/src/studio_app/tests.rs
@@ -268,6 +268,7 @@ fn studio_preview_uses_cached_poll_failure_state_instead_of_stale_values() {
             },
             weekly: Default::default(),
             weekly_label: None,
+            credits: None,
         },
     )]));
     app.usage_poll_ok = false;

--- a/src/theme_engine.rs
+++ b/src/theme_engine.rs
@@ -1338,6 +1338,11 @@ impl DataContext {
         self.insert(&format!("{name}.weekly.percentage"), weekly);
         self.insert(&format!("{name}.weekly.remaining"), 100.0 - weekly);
         self.insert(&format!("{name}.available"), usage.is_some() as u8 as f64);
+        // Carried over from an earlier poll: real figures, not current ones.
+        self.insert(
+            &format!("{name}.stale"),
+            usage.is_some_and(|usage| usage.stale) as u8 as f64,
+        );
         // Credits are absent for most accounts, so `credits.available` is what
         // a theme should gate the overlay on rather than `available`.
         let credits = usage.and_then(|usage| usage.credits.as_ref());

--- a/src/theme_engine.rs
+++ b/src/theme_engine.rs
@@ -1338,6 +1338,28 @@ impl DataContext {
         self.insert(&format!("{name}.weekly.percentage"), weekly);
         self.insert(&format!("{name}.weekly.remaining"), 100.0 - weekly);
         self.insert(&format!("{name}.available"), usage.is_some() as u8 as f64);
+        // Credits are absent for most accounts, so `credits.available` is what
+        // a theme should gate the overlay on rather than `available`.
+        let credits = usage.and_then(|usage| usage.credits.as_ref());
+        let credits_percentage = credits.map(|credits| credits.percentage).unwrap_or(0.0);
+        self.insert(&format!("{name}.credits.percentage"), credits_percentage);
+        self.insert(
+            &format!("{name}.credits.remaining"),
+            100.0 - credits_percentage,
+        );
+        // Currency, unlike the percentages either side of it.
+        self.insert(
+            &format!("{name}.credits.balance"),
+            credits.map(|credits| credits.remaining).unwrap_or(0.0),
+        );
+        self.insert(
+            &format!("{name}.credits.total"),
+            credits.map(|credits| credits.total).unwrap_or(0.0),
+        );
+        self.insert(
+            &format!("{name}.credits.available"),
+            credits.is_some() as u8 as f64,
+        );
         let reset_value = |reset: Option<std::time::SystemTime>| {
             let unix = reset
                 .and_then(|value| value.duration_since(std::time::UNIX_EPOCH).ok())

--- a/src/theme_engine.rs
+++ b/src/theme_engine.rs
@@ -1360,6 +1360,17 @@ impl DataContext {
             &format!("{name}.credits.available"),
             credits.is_some() as u8 as f64,
         );
+        // The single figure a badge should show: whatever is closest to its
+        // limit. A provider can switch a window off entirely -- Codex has its
+        // five-hour window disabled -- so binding a badge to one window alone
+        // leaves it reporting 0% while another allowance is spent.
+        self.insert(
+            &format!("{name}.headline.percentage"),
+            match credits {
+                Some(credits) => credits.percentage,
+                None => session.max(weekly),
+            },
+        );
         let reset_value = |reset: Option<std::time::SystemTime>| {
             let unix = reset
                 .and_then(|value| value.duration_since(std::time::UNIX_EPOCH).ok())

--- a/src/theme_engine/tests.rs
+++ b/src/theme_engine/tests.rs
@@ -308,6 +308,7 @@ fn usage_lines_handle_loading_errors_missing_resets_and_language() {
             weekly: crate::models::UsageSection::default(),
             weekly_label: None,
             credits: None,
+            stale: false,
         },
     )]);
     let ready = DataContext::from_usage_with_runtime(
@@ -478,6 +479,7 @@ fn reset_stats_and_duration_formats_are_available_to_every_provider() {
             weekly: crate::models::UsageSection::default(),
             weekly_label: None,
             credits: None,
+            stale: false,
         },
     )]);
     let context = DataContext::from_usage(Some(&usage), &Canvas::default());

--- a/src/theme_engine/tests.rs
+++ b/src/theme_engine/tests.rs
@@ -1403,3 +1403,48 @@ fn hit_testing_selects_the_topmost_interactive_layer() {
         Some("top".into())
     );
 }
+
+#[test]
+fn headline_follows_the_window_closest_to_its_limit() {
+    use crate::models::{CreditsSection, UsageData, UsageSection};
+
+    let percent = |value: f64| UsageSection {
+        percentage: value,
+        resets_at: None,
+    };
+    let context = |usage: UsageData| {
+        DataContext::from_usage(
+            Some(&AppUsageData::from_iter([(ProviderId::Codex, usage)])),
+            &Canvas::default(),
+        )
+    };
+
+    // A disabled session window must not hold the badge at zero while the
+    // weekly allowance is spent.
+    let spent_weekly = context(UsageData {
+        session: percent(0.0),
+        weekly: percent(100.0),
+        ..Default::default()
+    });
+    assert_eq!(spent_weekly.get("codex.headline.percentage"), Some(100.0));
+
+    let busy_session = context(UsageData {
+        session: percent(72.0),
+        weekly: percent(12.0),
+        ..Default::default()
+    });
+    assert_eq!(busy_session.get("codex.headline.percentage"), Some(72.0));
+
+    // Once credits are covering the overflow they are the live figure.
+    let on_credits = context(UsageData {
+        session: percent(0.0),
+        weekly: percent(100.0),
+        credits: Some(CreditsSection {
+            percentage: 41.0,
+            remaining: 24.1,
+            total: 40.83,
+        }),
+        ..Default::default()
+    });
+    assert_eq!(on_credits.get("codex.headline.percentage"), Some(41.0));
+}

--- a/src/theme_engine/tests.rs
+++ b/src/theme_engine/tests.rs
@@ -366,8 +366,10 @@ fn starter_theme_round_trips_and_validates() {
         })
         .collect::<Vec<_>>();
     // Classic contains separate light and dark progress layers so the
-    // 1.4.9 palette follows the taskbar mode without runtime recolouring.
-    assert_eq!(segments, vec![10; 20]);
+    // 1.4.9 palette follows the taskbar mode without runtime recolouring:
+    // five providers over two windows in two modes, plus a credit overlay on
+    // the weekly row of the two providers that report credits.
+    assert_eq!(segments, vec![10; 5 * 2 * 2 + 2 * 2]);
     assert!(theme.surfaces[0]
         .children
         .iter()
@@ -1449,4 +1451,41 @@ fn headline_follows_the_window_closest_to_its_limit() {
         ..Default::default()
     });
     assert_eq!(on_credits.get("codex.headline.percentage"), Some(41.0));
+}
+
+#[test]
+fn credit_badges_abbreviate_a_balance_too_wide_for_the_tray() {
+    use crate::models::{CreditsSection, UsageData};
+
+    let context = |balance: f64| {
+        DataContext::from_usage(
+            Some(&AppUsageData::from_iter([(
+                ProviderId::Codex,
+                UsageData {
+                    credits: Some(CreditsSection {
+                        percentage: 10.0,
+                        remaining: balance,
+                        total: 2000.0,
+                    }),
+                    ..Default::default()
+                },
+            )])),
+            &Canvas::default(),
+        )
+    };
+
+    // Up to three figures the badge shows whole dollars.
+    assert_eq!(
+        format_template("{codex.credits.balance:0}", &context(39.25)),
+        "39"
+    );
+    assert_eq!(
+        format_template("{codex.credits.balance:0}", &context(450.0)),
+        "450"
+    );
+    // Four will not fit, so the tray falls back to thousands.
+    assert_eq!(
+        format_template("{codex.credits.balance / 1000:0.0}k", &context(1234.0)),
+        "1.2k"
+    );
 }

--- a/src/theme_engine/tests.rs
+++ b/src/theme_engine/tests.rs
@@ -307,6 +307,7 @@ fn usage_lines_handle_loading_errors_missing_resets_and_language() {
             },
             weekly: crate::models::UsageSection::default(),
             weekly_label: None,
+            credits: None,
         },
     )]);
     let ready = DataContext::from_usage_with_runtime(
@@ -476,6 +477,7 @@ fn reset_stats_and_duration_formats_are_available_to_every_provider() {
             },
             weekly: crate::models::UsageSection::default(),
             weekly_label: None,
+            credits: None,
         },
     )]);
     let context = DataContext::from_usage(Some(&usage), &Canvas::default());

--- a/src/theme_engine/theme_expression.rs
+++ b/src/theme_engine/theme_expression.rs
@@ -319,7 +319,7 @@ pub(super) fn format_usage_line(base: &str, context: &DataContext) -> Option<Str
             provider,
             "active" | "claude" | "codex" | "antigravity" | "opencode" | "cursor"
         )
-        || !matches!(window, "session" | "weekly")
+        || !matches!(window, "session" | "weekly" | "credits")
     {
         return None;
     }

--- a/src/themes/classic-usage-widget.json
+++ b/src/themes/classic-usage-widget.json
@@ -549,7 +549,7 @@
         {
           "id": "claude-weekly-value-dark",
           "name": "dark Claude Code 7-day value",
-          "render": "system.dark",
+          "render": "(system.dark) && !claude.credits.available",
           "parent": "claude-provider",
           "x": "ceil(10 / max(1, providers.count)) * 11 - 1 + 4",
           "y": "28",
@@ -596,7 +596,7 @@
         {
           "id": "claude-weekly-value-light",
           "name": "light Claude Code 7-day value",
-          "render": "1 - system.dark",
+          "render": "(1 - system.dark) && !claude.credits.available",
           "parent": "claude-provider",
           "x": "ceil(10 / max(1, providers.count)) * 11 - 1 + 4",
           "y": "28",
@@ -745,7 +745,7 @@
         {
           "id": "codex-weekly-value-dark",
           "name": "dark Codex 7-day value",
-          "render": "system.dark",
+          "render": "(system.dark) && !codex.credits.available",
           "parent": "codex-provider",
           "x": "ceil(10 / max(1, providers.count)) * 11 - 1 + 4",
           "y": "28",
@@ -792,7 +792,7 @@
         {
           "id": "codex-weekly-value-light",
           "name": "light Codex 7-day value",
-          "render": "1 - system.dark",
+          "render": "(1 - system.dark) && !codex.credits.available",
           "parent": "codex-provider",
           "x": "ceil(10 / max(1, providers.count)) * 11 - 1 + 4",
           "y": "28",
@@ -1203,6 +1203,206 @@
               "color": "#1B5E20FF"
             }
           }
+        },
+        {
+          "id": "claude-credits-segments-dark",
+          "name": "dark claude credit overlay",
+          "render": "(system.dark) && claude.credits.available",
+          "parent": "claude-provider",
+          "y": "28",
+          "width": "ceil(10 / max(1, providers.count)) * 11 - 1",
+          "height": "13",
+          "content": {
+            "type": "progress",
+            "value": "claude.credits.percentage",
+            "direction": "left_to_right",
+            "fill": {
+              "color": "#F5A623FF",
+              "opacity": "1"
+            },
+            "track": {
+              "color": "#00000000",
+              "opacity": "0"
+            },
+            "corner_radius": "2",
+            "segments": 10,
+            "segments_expression": "ceil(10 / max(1, providers.count))",
+            "segment_gap": "1"
+          }
+        },
+        {
+          "id": "claude-credits-value-dark",
+          "name": "dark claude credit balance",
+          "render": "(system.dark) && claude.credits.available",
+          "parent": "claude-provider",
+          "x": "ceil(10 / max(1, providers.count)) * 11 - 1 + 4",
+          "y": "28",
+          "width": "62",
+          "height": "13",
+          "content": {
+            "type": "text",
+            "template": "${claude.credits.balance:0.00}",
+            "font_family": "Segoe UI",
+            "font_size": "12",
+            "weight": "medium",
+            "rendering": "clear_type",
+            "contrast": "1",
+            "align": "left",
+            "color": {
+              "color": "#F5A623FF",
+              "opacity": "1"
+            }
+          }
+        },
+        {
+          "id": "claude-credits-segments-light",
+          "name": "light claude credit overlay",
+          "render": "(1 - system.dark) && claude.credits.available",
+          "parent": "claude-provider",
+          "y": "28",
+          "width": "ceil(10 / max(1, providers.count)) * 11 - 1",
+          "height": "13",
+          "content": {
+            "type": "progress",
+            "value": "claude.credits.percentage",
+            "direction": "left_to_right",
+            "fill": {
+              "color": "#C77700FF",
+              "opacity": "1"
+            },
+            "track": {
+              "color": "#00000000",
+              "opacity": "0"
+            },
+            "corner_radius": "2",
+            "segments": 10,
+            "segments_expression": "ceil(10 / max(1, providers.count))",
+            "segment_gap": "1"
+          }
+        },
+        {
+          "id": "claude-credits-value-light",
+          "name": "light claude credit balance",
+          "render": "(1 - system.dark) && claude.credits.available",
+          "parent": "claude-provider",
+          "x": "ceil(10 / max(1, providers.count)) * 11 - 1 + 4",
+          "y": "28",
+          "width": "62",
+          "height": "13",
+          "content": {
+            "type": "text",
+            "template": "${claude.credits.balance:0.00}",
+            "font_family": "Segoe UI",
+            "font_size": "12",
+            "weight": "medium",
+            "rendering": "clear_type",
+            "contrast": "1",
+            "align": "left",
+            "color": {
+              "color": "#C77700FF",
+              "opacity": "1"
+            }
+          }
+        },
+        {
+          "id": "codex-credits-segments-dark",
+          "name": "dark codex credit overlay",
+          "render": "(system.dark) && codex.credits.available",
+          "parent": "codex-provider",
+          "y": "28",
+          "width": "ceil(10 / max(1, providers.count)) * 11 - 1",
+          "height": "13",
+          "content": {
+            "type": "progress",
+            "value": "codex.credits.percentage",
+            "direction": "left_to_right",
+            "fill": {
+              "color": "#F5A623FF",
+              "opacity": "1"
+            },
+            "track": {
+              "color": "#00000000",
+              "opacity": "0"
+            },
+            "corner_radius": "2",
+            "segments": 10,
+            "segments_expression": "ceil(10 / max(1, providers.count))",
+            "segment_gap": "1"
+          }
+        },
+        {
+          "id": "codex-credits-value-dark",
+          "name": "dark codex credit balance",
+          "render": "(system.dark) && codex.credits.available",
+          "parent": "codex-provider",
+          "x": "ceil(10 / max(1, providers.count)) * 11 - 1 + 4",
+          "y": "28",
+          "width": "62",
+          "height": "13",
+          "content": {
+            "type": "text",
+            "template": "${codex.credits.balance:0.00}",
+            "font_family": "Segoe UI",
+            "font_size": "12",
+            "weight": "medium",
+            "rendering": "clear_type",
+            "contrast": "1",
+            "align": "left",
+            "color": {
+              "color": "#F5A623FF",
+              "opacity": "1"
+            }
+          }
+        },
+        {
+          "id": "codex-credits-segments-light",
+          "name": "light codex credit overlay",
+          "render": "(1 - system.dark) && codex.credits.available",
+          "parent": "codex-provider",
+          "y": "28",
+          "width": "ceil(10 / max(1, providers.count)) * 11 - 1",
+          "height": "13",
+          "content": {
+            "type": "progress",
+            "value": "codex.credits.percentage",
+            "direction": "left_to_right",
+            "fill": {
+              "color": "#C77700FF",
+              "opacity": "1"
+            },
+            "track": {
+              "color": "#00000000",
+              "opacity": "0"
+            },
+            "corner_radius": "2",
+            "segments": 10,
+            "segments_expression": "ceil(10 / max(1, providers.count))",
+            "segment_gap": "1"
+          }
+        },
+        {
+          "id": "codex-credits-value-light",
+          "name": "light codex credit balance",
+          "render": "(1 - system.dark) && codex.credits.available",
+          "parent": "codex-provider",
+          "x": "ceil(10 / max(1, providers.count)) * 11 - 1 + 4",
+          "y": "28",
+          "width": "62",
+          "height": "13",
+          "content": {
+            "type": "text",
+            "template": "${codex.credits.balance:0.00}",
+            "font_family": "Segoe UI",
+            "font_size": "12",
+            "weight": "medium",
+            "rendering": "clear_type",
+            "contrast": "1",
+            "align": "left",
+            "color": {
+              "color": "#C77700FF",
+              "opacity": "1"
+            }
+          }
         }
       ]
     },
@@ -1231,7 +1431,7 @@
         {
           "id": "claude-tray-70-color",
           "name": "Claude 50 to 70 percent colour transition",
-          "render": "claude.session.percentage > 50",
+          "render": "claude.headline.percentage > 50",
           "parent": "claude-tray-icon",
           "width": "64",
           "height": "64",
@@ -1247,7 +1447,7 @@
         {
           "id": "claude-tray-85-color",
           "name": "Claude 70 to 85 percent colour transition",
-          "render": "claude.session.percentage > 70",
+          "render": "claude.headline.percentage > 70",
           "parent": "claude-tray-icon",
           "width": "64",
           "height": "64",
@@ -1263,7 +1463,7 @@
         {
           "id": "claude-tray-95-color",
           "name": "Claude 85 to 95 percent colour transition",
-          "render": "claude.session.percentage > 85",
+          "render": "claude.headline.percentage > 85",
           "parent": "claude-tray-icon",
           "width": "64",
           "height": "64",
@@ -1279,7 +1479,7 @@
         {
           "id": "claude-tray-100-color",
           "name": "Claude 95 to 100 percent colour transition",
-          "render": "claude.session.percentage > 95",
+          "render": "claude.headline.percentage > 95",
           "parent": "claude-tray-icon",
           "width": "64",
           "height": "64",
@@ -1295,13 +1495,13 @@
         {
           "id": "claude-tray-one-digit",
           "name": "Claude one-digit percentage",
-          "render": "data.poll_ok && claude.available && claude.session.percentage < 9.5",
+          "render": "(data.poll_ok && claude.available && claude.headline.percentage < 9.5) && claude.credits.available == 0",
           "parent": "claude-tray-icon",
           "width": "64",
           "height": "64",
           "content": {
             "type": "text",
-            "template": "{claude.session.percentage:0}",
+            "template": "{claude.headline.percentage:0}",
             "font_family": "Arial Bold",
             "font_size": "50",
             "weight": "bold",
@@ -1314,13 +1514,13 @@
         {
           "id": "claude-tray-two-digits",
           "name": "Claude two-digit percentage",
-          "render": "data.poll_ok && claude.available && claude.session.percentage >= 9.5 && claude.session.percentage < 99.5",
+          "render": "(data.poll_ok && claude.available && claude.headline.percentage >= 9.5 && claude.headline.percentage < 99.5) && claude.credits.available == 0",
           "parent": "claude-tray-icon",
           "width": "64",
           "height": "64",
           "content": {
             "type": "text",
-            "template": "{claude.session.percentage:0}",
+            "template": "{claude.headline.percentage:0}",
             "font_family": "Arial Bold",
             "font_size": "42",
             "weight": "bold",
@@ -1333,13 +1533,89 @@
         {
           "id": "claude-tray-three-digits",
           "name": "Claude three-digit percentage",
-          "render": "data.poll_ok && claude.available && claude.session.percentage >= 99.5",
+          "render": "(data.poll_ok && claude.available && claude.headline.percentage >= 99.5) && claude.credits.available == 0",
           "parent": "claude-tray-icon",
           "width": "64",
           "height": "64",
           "content": {
             "type": "text",
-            "template": "{claude.session.percentage:0}",
+            "template": "{claude.headline.percentage:0}",
+            "font_family": "Arial Bold",
+            "font_size": "30",
+            "weight": "bold",
+            "align": "center",
+            "color": {
+              "color": "#FFFFFFFF"
+            }
+          }
+        },
+        {
+          "id": "claude-tray-credit-one-digit",
+          "name": "claude credit balance badge",
+          "render": "data.poll_ok && claude.available && claude.credits.available && claude.credits.balance < 9.5",
+          "parent": "claude-tray-icon",
+          "width": "64",
+          "height": "64",
+          "content": {
+            "type": "text",
+            "template": "{claude.credits.balance:0}",
+            "font_family": "Arial Bold",
+            "font_size": "50",
+            "weight": "bold",
+            "align": "center",
+            "color": {
+              "color": "#FFFFFFFF"
+            }
+          }
+        },
+        {
+          "id": "claude-tray-credit-two-digits",
+          "name": "claude credit balance badge",
+          "render": "data.poll_ok && claude.available && claude.credits.available && claude.credits.balance >= 9.5 && claude.credits.balance < 99.5",
+          "parent": "claude-tray-icon",
+          "width": "64",
+          "height": "64",
+          "content": {
+            "type": "text",
+            "template": "{claude.credits.balance:0}",
+            "font_family": "Arial Bold",
+            "font_size": "42",
+            "weight": "bold",
+            "align": "center",
+            "color": {
+              "color": "#FFFFFFFF"
+            }
+          }
+        },
+        {
+          "id": "claude-tray-credit-three-digits",
+          "name": "claude credit balance badge",
+          "render": "data.poll_ok && claude.available && claude.credits.available && claude.credits.balance >= 99.5 && claude.credits.balance < 999.5",
+          "parent": "claude-tray-icon",
+          "width": "64",
+          "height": "64",
+          "content": {
+            "type": "text",
+            "template": "{claude.credits.balance:0}",
+            "font_family": "Arial Bold",
+            "font_size": "30",
+            "weight": "bold",
+            "align": "center",
+            "color": {
+              "color": "#FFFFFFFF"
+            }
+          }
+        },
+        {
+          "id": "claude-tray-credit-thousands",
+          "name": "claude credit balance badge",
+          "render": "data.poll_ok && claude.available && claude.credits.available && claude.credits.balance >= 999.5",
+          "parent": "claude-tray-icon",
+          "width": "64",
+          "height": "64",
+          "content": {
+            "type": "text",
+            "template": "{claude.credits.balance / 1000:0.0}k",
             "font_family": "Arial Bold",
             "font_size": "30",
             "weight": "bold",
@@ -1376,7 +1652,7 @@
         {
           "id": "codex-tray-high-outline",
           "name": "Codex high-usage dark outline",
-          "render": "codex.session.percentage >= 90",
+          "render": "codex.headline.percentage >= 90",
           "parent": "codex-tray-icon",
           "width": "64",
           "height": "64",
@@ -1391,7 +1667,7 @@
         {
           "id": "codex-tray-low-fill",
           "name": "Codex normal dark fill",
-          "render": "codex.session.percentage < 90",
+          "render": "codex.headline.percentage < 90",
           "parent": "codex-tray-icon",
           "x": "3",
           "y": "3",
@@ -1408,7 +1684,7 @@
         {
           "id": "codex-tray-high-fill",
           "name": "Codex high-usage white fill",
-          "render": "codex.session.percentage >= 90",
+          "render": "codex.headline.percentage >= 90",
           "parent": "codex-tray-icon",
           "x": "3",
           "y": "3",
@@ -1444,13 +1720,13 @@
         {
           "id": "codex-tray-low-one-digit",
           "name": "Codex normal one-digit percentage",
-          "render": "data.poll_ok && codex.available && codex.session.percentage < 9.5",
+          "render": "(data.poll_ok && codex.available && codex.headline.percentage < 9.5) && codex.credits.available == 0",
           "parent": "codex-tray-icon",
           "width": "64",
           "height": "64",
           "content": {
             "type": "text",
-            "template": "{codex.session.percentage:0}",
+            "template": "{codex.headline.percentage:0}",
             "font_family": "Arial Bold",
             "font_size": "50",
             "weight": "bold",
@@ -1463,13 +1739,13 @@
         {
           "id": "codex-tray-low-two-digits",
           "name": "Codex normal two-digit percentage",
-          "render": "data.poll_ok && codex.available && codex.session.percentage >= 9.5 && codex.session.percentage < 90",
+          "render": "(data.poll_ok && codex.available && codex.headline.percentage >= 9.5 && codex.headline.percentage < 90) && codex.credits.available == 0",
           "parent": "codex-tray-icon",
           "width": "64",
           "height": "64",
           "content": {
             "type": "text",
-            "template": "{codex.session.percentage:0}",
+            "template": "{codex.headline.percentage:0}",
             "font_family": "Arial Bold",
             "font_size": "42",
             "weight": "bold",
@@ -1482,13 +1758,13 @@
         {
           "id": "codex-tray-high-two-digits",
           "name": "Codex high-usage two-digit percentage",
-          "render": "data.poll_ok && codex.available && codex.session.percentage >= 90 && codex.session.percentage < 99.5",
+          "render": "(data.poll_ok && codex.available && codex.headline.percentage >= 90 && codex.headline.percentage < 99.5) && codex.credits.available == 0",
           "parent": "codex-tray-icon",
           "width": "64",
           "height": "64",
           "content": {
             "type": "text",
-            "template": "{codex.session.percentage:0}",
+            "template": "{codex.headline.percentage:0}",
             "font_family": "Arial Bold",
             "font_size": "42",
             "weight": "bold",
@@ -1501,13 +1777,89 @@
         {
           "id": "codex-tray-high-three-digits",
           "name": "Codex high-usage three-digit percentage",
-          "render": "data.poll_ok && codex.available && codex.session.percentage >= 99.5",
+          "render": "(data.poll_ok && codex.available && codex.headline.percentage >= 99.5) && codex.credits.available == 0",
           "parent": "codex-tray-icon",
           "width": "64",
           "height": "64",
           "content": {
             "type": "text",
-            "template": "{codex.session.percentage:0}",
+            "template": "{codex.headline.percentage:0}",
+            "font_family": "Arial Bold",
+            "font_size": "30",
+            "weight": "bold",
+            "align": "center",
+            "color": {
+              "color": "#111111FF"
+            }
+          }
+        },
+        {
+          "id": "codex-tray-credit-one-digit",
+          "name": "codex credit balance badge",
+          "render": "data.poll_ok && codex.available && codex.credits.available && codex.credits.balance < 9.5",
+          "parent": "codex-tray-icon",
+          "width": "64",
+          "height": "64",
+          "content": {
+            "type": "text",
+            "template": "{codex.credits.balance:0}",
+            "font_family": "Arial Bold",
+            "font_size": "50",
+            "weight": "bold",
+            "align": "center",
+            "color": {
+              "color": "#FFFFFFFF"
+            }
+          }
+        },
+        {
+          "id": "codex-tray-credit-two-digits",
+          "name": "codex credit balance badge",
+          "render": "data.poll_ok && codex.available && codex.credits.available && codex.credits.balance >= 9.5 && codex.credits.balance < 99.5",
+          "parent": "codex-tray-icon",
+          "width": "64",
+          "height": "64",
+          "content": {
+            "type": "text",
+            "template": "{codex.credits.balance:0}",
+            "font_family": "Arial Bold",
+            "font_size": "42",
+            "weight": "bold",
+            "align": "center",
+            "color": {
+              "color": "#FFFFFFFF"
+            }
+          }
+        },
+        {
+          "id": "codex-tray-credit-three-digits",
+          "name": "codex credit balance badge",
+          "render": "data.poll_ok && codex.available && codex.credits.available && codex.credits.balance >= 99.5 && codex.credits.balance < 999.5",
+          "parent": "codex-tray-icon",
+          "width": "64",
+          "height": "64",
+          "content": {
+            "type": "text",
+            "template": "{codex.credits.balance:0}",
+            "font_family": "Arial Bold",
+            "font_size": "30",
+            "weight": "bold",
+            "align": "center",
+            "color": {
+              "color": "#111111FF"
+            }
+          }
+        },
+        {
+          "id": "codex-tray-credit-thousands",
+          "name": "codex credit balance badge",
+          "render": "data.poll_ok && codex.available && codex.credits.available && codex.credits.balance >= 999.5",
+          "parent": "codex-tray-icon",
+          "width": "64",
+          "height": "64",
+          "content": {
+            "type": "text",
+            "template": "{codex.credits.balance / 1000:0.0}k",
             "font_family": "Arial Bold",
             "font_size": "30",
             "weight": "bold",
@@ -1544,7 +1896,7 @@
         {
           "id": "antigravity-tray-high-outline",
           "name": "Antigravity high-usage blue outline",
-          "render": "antigravity.session.percentage >= 90",
+          "render": "antigravity.headline.percentage >= 90",
           "parent": "antigravity-tray-icon",
           "width": "64",
           "height": "64",
@@ -1559,7 +1911,7 @@
         {
           "id": "antigravity-tray-low-fill",
           "name": "Antigravity normal blue fill",
-          "render": "antigravity.session.percentage < 90",
+          "render": "antigravity.headline.percentage < 90",
           "parent": "antigravity-tray-icon",
           "x": "3",
           "y": "3",
@@ -1576,7 +1928,7 @@
         {
           "id": "antigravity-tray-high-fill",
           "name": "Antigravity high-usage white fill",
-          "render": "antigravity.session.percentage >= 90",
+          "render": "antigravity.headline.percentage >= 90",
           "parent": "antigravity-tray-icon",
           "x": "3",
           "y": "3",
@@ -1612,13 +1964,13 @@
         {
           "id": "antigravity-tray-low-one-digit",
           "name": "Antigravity normal one-digit percentage",
-          "render": "data.poll_ok && antigravity.available && antigravity.session.percentage < 9.5",
+          "render": "data.poll_ok && antigravity.available && antigravity.headline.percentage < 9.5",
           "parent": "antigravity-tray-icon",
           "width": "64",
           "height": "64",
           "content": {
             "type": "text",
-            "template": "{antigravity.session.percentage:0}",
+            "template": "{antigravity.headline.percentage:0}",
             "font_family": "Arial Bold",
             "font_size": "50",
             "weight": "bold",
@@ -1631,13 +1983,13 @@
         {
           "id": "antigravity-tray-low-two-digits",
           "name": "Antigravity normal two-digit percentage",
-          "render": "data.poll_ok && antigravity.available && antigravity.session.percentage >= 9.5 && antigravity.session.percentage < 90",
+          "render": "data.poll_ok && antigravity.available && antigravity.headline.percentage >= 9.5 && antigravity.headline.percentage < 90",
           "parent": "antigravity-tray-icon",
           "width": "64",
           "height": "64",
           "content": {
             "type": "text",
-            "template": "{antigravity.session.percentage:0}",
+            "template": "{antigravity.headline.percentage:0}",
             "font_family": "Arial Bold",
             "font_size": "42",
             "weight": "bold",
@@ -1650,13 +2002,13 @@
         {
           "id": "antigravity-tray-high-two-digits",
           "name": "Antigravity high-usage two-digit percentage",
-          "render": "data.poll_ok && antigravity.available && antigravity.session.percentage >= 90 && antigravity.session.percentage < 99.5",
+          "render": "data.poll_ok && antigravity.available && antigravity.headline.percentage >= 90 && antigravity.headline.percentage < 99.5",
           "parent": "antigravity-tray-icon",
           "width": "64",
           "height": "64",
           "content": {
             "type": "text",
-            "template": "{antigravity.session.percentage:0}",
+            "template": "{antigravity.headline.percentage:0}",
             "font_family": "Arial Bold",
             "font_size": "42",
             "weight": "bold",
@@ -1669,13 +2021,13 @@
         {
           "id": "antigravity-tray-high-three-digits",
           "name": "Antigravity high-usage three-digit percentage",
-          "render": "data.poll_ok && antigravity.available && antigravity.session.percentage >= 99.5",
+          "render": "data.poll_ok && antigravity.available && antigravity.headline.percentage >= 99.5",
           "parent": "antigravity-tray-icon",
           "width": "64",
           "height": "64",
           "content": {
             "type": "text",
-            "template": "{antigravity.session.percentage:0}",
+            "template": "{antigravity.headline.percentage:0}",
             "font_family": "Arial Bold",
             "font_size": "30",
             "weight": "bold",
@@ -1712,7 +2064,7 @@
         {
           "id": "cursor-tray-high-outline",
           "name": "Cursor high-usage black outline",
-          "render": "cursor.session.percentage >= 90",
+          "render": "cursor.headline.percentage >= 90",
           "parent": "cursor-tray-icon",
           "width": "64",
           "height": "64",
@@ -1727,7 +2079,7 @@
         {
           "id": "cursor-tray-low-fill",
           "name": "Cursor normal black fill",
-          "render": "cursor.session.percentage < 90",
+          "render": "cursor.headline.percentage < 90",
           "parent": "cursor-tray-icon",
           "x": "3",
           "y": "3",
@@ -1744,7 +2096,7 @@
         {
           "id": "cursor-tray-high-fill",
           "name": "Cursor high-usage white fill",
-          "render": "cursor.session.percentage >= 90",
+          "render": "cursor.headline.percentage >= 90",
           "parent": "cursor-tray-icon",
           "x": "3",
           "y": "3",
@@ -1780,13 +2132,13 @@
         {
           "id": "cursor-tray-low-one-digit",
           "name": "Cursor normal one-digit percentage",
-          "render": "data.poll_ok && cursor.available && cursor.session.percentage < 9.5",
+          "render": "data.poll_ok && cursor.available && cursor.headline.percentage < 9.5",
           "parent": "cursor-tray-icon",
           "width": "64",
           "height": "64",
           "content": {
             "type": "text",
-            "template": "{cursor.session.percentage:0}",
+            "template": "{cursor.headline.percentage:0}",
             "font_family": "Arial Bold",
             "font_size": "50",
             "weight": "bold",
@@ -1799,13 +2151,13 @@
         {
           "id": "cursor-tray-low-two-digits",
           "name": "Cursor normal two-digit percentage",
-          "render": "data.poll_ok && cursor.available && cursor.session.percentage >= 9.5 && cursor.session.percentage < 90",
+          "render": "data.poll_ok && cursor.available && cursor.headline.percentage >= 9.5 && cursor.headline.percentage < 90",
           "parent": "cursor-tray-icon",
           "width": "64",
           "height": "64",
           "content": {
             "type": "text",
-            "template": "{cursor.session.percentage:0}",
+            "template": "{cursor.headline.percentage:0}",
             "font_family": "Arial Bold",
             "font_size": "42",
             "weight": "bold",
@@ -1818,13 +2170,13 @@
         {
           "id": "cursor-tray-high-two-digits",
           "name": "Cursor high-usage two-digit percentage",
-          "render": "data.poll_ok && cursor.available && cursor.session.percentage >= 90 && cursor.session.percentage < 99.5",
+          "render": "data.poll_ok && cursor.available && cursor.headline.percentage >= 90 && cursor.headline.percentage < 99.5",
           "parent": "cursor-tray-icon",
           "width": "64",
           "height": "64",
           "content": {
             "type": "text",
-            "template": "{cursor.session.percentage:0}",
+            "template": "{cursor.headline.percentage:0}",
             "font_family": "Arial Bold",
             "font_size": "42",
             "weight": "bold",
@@ -1837,13 +2189,13 @@
         {
           "id": "cursor-tray-high-three-digits",
           "name": "Cursor high-usage three-digit percentage",
-          "render": "data.poll_ok && cursor.available && cursor.session.percentage >= 99.5",
+          "render": "data.poll_ok && cursor.available && cursor.headline.percentage >= 99.5",
           "parent": "cursor-tray-icon",
           "width": "64",
           "height": "64",
           "content": {
             "type": "text",
-            "template": "{cursor.session.percentage:0}",
+            "template": "{cursor.headline.percentage:0}",
             "font_family": "Arial Bold",
             "font_size": "30",
             "weight": "bold",
@@ -1880,7 +2232,7 @@
         {
           "id": "opencode-tray-high-outline",
           "name": "OpenCode high-usage green outline",
-          "render": "opencode.session.percentage >= 90",
+          "render": "opencode.headline.percentage >= 90",
           "parent": "opencode-tray-icon",
           "width": "64",
           "height": "64",
@@ -1895,7 +2247,7 @@
         {
           "id": "opencode-tray-low-fill",
           "name": "OpenCode normal green fill",
-          "render": "opencode.session.percentage < 90",
+          "render": "opencode.headline.percentage < 90",
           "parent": "opencode-tray-icon",
           "x": "3",
           "y": "3",
@@ -1912,7 +2264,7 @@
         {
           "id": "opencode-tray-high-fill",
           "name": "OpenCode high-usage white fill",
-          "render": "opencode.session.percentage >= 90",
+          "render": "opencode.headline.percentage >= 90",
           "parent": "opencode-tray-icon",
           "x": "3",
           "y": "3",
@@ -1948,13 +2300,13 @@
         {
           "id": "opencode-tray-low-one-digit",
           "name": "OpenCode normal one-digit percentage",
-          "render": "data.poll_ok && opencode.available && opencode.session.percentage < 9.5",
+          "render": "data.poll_ok && opencode.available && opencode.headline.percentage < 9.5",
           "parent": "opencode-tray-icon",
           "width": "64",
           "height": "64",
           "content": {
             "type": "text",
-            "template": "{opencode.session.percentage:0}",
+            "template": "{opencode.headline.percentage:0}",
             "font_family": "Arial Bold",
             "font_size": "50",
             "weight": "bold",
@@ -1967,13 +2319,13 @@
         {
           "id": "opencode-tray-low-two-digits",
           "name": "OpenCode normal two-digit percentage",
-          "render": "data.poll_ok && opencode.available && opencode.session.percentage >= 9.5 && opencode.session.percentage < 90",
+          "render": "data.poll_ok && opencode.available && opencode.headline.percentage >= 9.5 && opencode.headline.percentage < 90",
           "parent": "opencode-tray-icon",
           "width": "64",
           "height": "64",
           "content": {
             "type": "text",
-            "template": "{opencode.session.percentage:0}",
+            "template": "{opencode.headline.percentage:0}",
             "font_family": "Arial Bold",
             "font_size": "42",
             "weight": "bold",
@@ -1986,13 +2338,13 @@
         {
           "id": "opencode-tray-high-two-digits",
           "name": "OpenCode high-usage two-digit percentage",
-          "render": "data.poll_ok && opencode.available && opencode.session.percentage >= 90 && opencode.session.percentage < 99.5",
+          "render": "data.poll_ok && opencode.available && opencode.headline.percentage >= 90 && opencode.headline.percentage < 99.5",
           "parent": "opencode-tray-icon",
           "width": "64",
           "height": "64",
           "content": {
             "type": "text",
-            "template": "{opencode.session.percentage:0}",
+            "template": "{opencode.headline.percentage:0}",
             "font_family": "Arial Bold",
             "font_size": "42",
             "weight": "bold",
@@ -2005,13 +2357,13 @@
         {
           "id": "opencode-tray-high-three-digits",
           "name": "OpenCode high-usage three-digit percentage",
-          "render": "data.poll_ok && opencode.available && opencode.session.percentage >= 99.5",
+          "render": "data.poll_ok && opencode.available && opencode.headline.percentage >= 99.5",
           "parent": "opencode-tray-icon",
           "width": "64",
           "height": "64",
           "content": {
             "type": "text",
-            "template": "{opencode.session.percentage:0}",
+            "template": "{opencode.headline.percentage:0}",
             "font_family": "Arial Bold",
             "font_size": "30",
             "weight": "bold",

--- a/src/window.rs
+++ b/src/window.rs
@@ -1893,8 +1893,12 @@ fn do_poll_once(hwnd: HWND) {
 
     match poller::poll(enabled_providers) {
         Ok(data) => {
-            let cache_data = data.clone();
             let mut state = lock_state();
+            let data = match state.as_ref().and_then(|s| s.data.as_ref()) {
+                Some(previous) => poller::carry_forward_failures(data, previous, enabled_providers),
+                None => data,
+            };
+            let cache_data = data.clone();
             if let Some(s) = state.as_mut() {
                 // Stop fast-poll if reset data is now fresh
                 if !poller::app_is_past_reset(&data) {


### PR DESCRIPTION
Closes #11.

![Codex over its weekly allowance and running on credits](https://raw.githubusercontent.com/brucemeek/Claude-Code-Usage-Monitor/pr-assets/credits-widget.png)

Codex over its weekly allowance and running on credits. The amber overlay grows across the spent bar as credits are drawn down, the readout swaps to the remaining balance, and the tray badge shows whole dollars. Claude stays on its ordinary windows because neither of its limits is reached.

Both Claude and Codex already report paid credits in payloads the monitor fetches on every poll, and both were dropped on the floor by the response structs. Adding them turned up three separate bugs underneath, which is why this is larger than the feature alone. Each is its own commit and each stands on its own if you would rather take them separately.

## Credits

The bars stay on the ordinary five-hour and weekly windows until two things are true at once: an allowance is spent, and a poll catches credits actually being drawn on. The second half is an observation rather than an assumption about when a provider decides to bill credits, so it holds whichever window ran out — including the five-hour one, which I could not verify either way.

**Claude** states a cap, so `spend.used` against `spend.limit` is a percentage directly, and a non-zero `used` is the "credits are in play" signal. No history needed.

**Codex** reports a balance with no ceiling, so the denominator has to be learned. The balance only falls as credits are spent, so any rise is a top-up that re-baselines the gauge. The first balance seen seeds the baseline and shows nothing until a later poll sees it fall. That state lives in `codex-credits.json` beside the usage cache, so it survives restarts and catches top-ups that happened while the app was closed. Tracking runs whether or not the gauge is shown, because a top-up has to move the baseline either way.

Codex bills at 25 credits to the dollar. That constant only affects the displayed amount — the gauge is a ratio of two credit figures, so if the rate ever changes the bar stays correct and only the label is wrong.

## Three bugs found underneath

**Codex rate-limit windows were assigned by slot, not by length.** Codex currently ships the weekly allowance in `primary_window` with `secondary_window` empty while the five-hour window is switched off, so an exhausted weekly was being drawn in the session bar while the weekly bar sat empty. On my account the widget read `5h 100%` / `7d 0%` when the truth was the reverse. Windows are now classified by `limit_window_seconds`, and the credit gate reads `rate_limit.limit_reached`, so both hold if the five-hour window returns in either slot.

**Every failure from the usage endpoint was treated as "this account cannot use it."** A 429, a 5xx, or a transport error fell through to the Messages API, which spends real quota on a request whose only purpose is reading rate-limit headers, and during a rate limit adds to the load that caused it while suppressing the backoff that would have relieved it. Transient failures now fail the poll so the widget holds its figures and backs off; only a genuine 4xx still falls through. I hit a real 429 while testing and watched the old path fire once a minute at the default-adjacent interval, so this is not hypothetical.

**One provider failing blanked its row.** A poll counts as successful as long as one provider answers, and the app then replaced the whole dataset with it — so a cycle where Claude failed and Codex succeeded dropped Claude entirely, rendering its row as an error once per refresh while the other rows kept updating. The existing "hold previous figures" path only covers a poll where *every* provider fails. Readings are now carried forward per provider and marked `stale` rather than passed off as current, exposed to themes as `<provider>.stale`. This one predates the rest; classifying 429s just made it happen often enough to notice.

## Theme

Without this the bindings have nothing consuming them and the feature is invisible. On the weekly row of Claude and Codex a credit overlay draws over the spent bar with a transparent track, so the amber fill grows across the exhausted allowance while the readout swaps to the remaining balance.

Tray badges now follow a new `<provider>.headline.percentage` — the figure closest to its limit — instead of the session window. With Codex's five-hour window disabled the badge sat at `0%` while the weekly was fully spent; it only looked right before because the weekly figure was landing in the session slot. Badges swap to whole dollars while credits are in play, abbreviating a thousand or more to `1.2k` since four figures do not fit the icon.

Everything is gated on `credits.available`, so nothing changes for anyone whose credits are not in play and no layout shifts.

New theme bindings: `<provider>.credits.percentage`, `.remaining`, `.balance`, `.total`, `.available`, plus `<provider>.headline.percentage` and `<provider>.stale`. `.balance` and `.total` are currency while everything either side of them is a percentage.

## Testing

`cargo build --release`, `cargo fmt --check`, and `cargo clippy --all-targets` are clean — the one remaining clippy warning, a `.fold` in `theme_storage.rs`, is pre-existing and untouched. **189 tests pass.**

New coverage: credit gauges for both providers including the seed-then-fall lifecycle, top-up re-baselining, the gates, and `overage_limit_reached`; window mapping by length in either slot and with the label absent; error classification across 429/500/503/401/403/404; carry-forward including not resurrecting a disabled provider; the headline figure; and the badge abbreviation thresholds.

Verified live on Windows 11 against real accounts: the window mapping flipping to `5h 0%` / `7d 100%`, the Codex gauge seeding and then appearing once the balance fell, the dollar badge and overlay rendering, and the 429 classification firing on a genuine rate limit.

`starter_theme_round_trips_and_validates` asserted 20 progress layers and now sees 24 with the four overlays; the assertion spells out where the number comes from rather than carrying a bare literal.

## Two things I could not verify

The 25-credits-to-the-dollar rate is inferred, not documented. Two readings divided cleanly and matched the balance shown in the Codex UI to the cent, but that is two samples. As above, only the label depends on it.

I do not know what status the usage endpoint returns for an account that genuinely lacks it — I have only ever seen 200 and 429 from it. I bucketed 404 and other 4xx as "unsupported" so the Messages fallback still fires for them, but if it actually returns something I classified as transient, the fallback would stop working for the people who need it. You may already know the answer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


